### PR TITLE
Use golang.org/x/oauth2 in client impl

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"gopkg.in/oauth2.v3"
+	oauth2 "gopkg.in/oauth2.v3"
 	"gopkg.in/oauth2.v3/errors"
 )
 
@@ -293,8 +293,6 @@ func (s *Server) ValidationTokenRequest(r *http.Request) (gt oauth2.GrantType, t
 			tgr.Code == "" {
 			err = errors.ErrInvalidRequest
 			return
-		} else if cid := r.FormValue("client_id"); cid == "" || cid != clientID {
-			err = errors.ErrInvalidClient
 		}
 	case oauth2.PasswordCredentials:
 		tgr.Scope = r.FormValue("scope")


### PR DESCRIPTION
This way it is easy to see if the server is still complying to the spec.

Also remove the check for client_id from server.go, which is not needed
any more now that the server uses basic HTTP auth to authenticate the
client.

ref. #35