### PR TITLE
TokenInfo in GenerateBasic

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -5,9 +5,10 @@ import "time"
 type (
 	// GenerateBasic provide the basis of the generated token data
 	GenerateBasic struct {
-		Client   ClientInfo
-		UserID   string
-		CreateAt time.Time
+		Client    ClientInfo
+		UserID    string
+		CreateAt  time.Time
+		TokenInfo TokenInfo
 	}
 
 	// AuthorizeGenerate generate the authorization code interface

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -172,9 +172,10 @@ func (m *Manager) GenerateAuthToken(rt oauth2.ResponseType, tgr *oauth2.TokenGen
 		ti = ti.New()
 
 		td := &oauth2.GenerateBasic{
-			Client:   cli,
-			UserID:   tgr.UserID,
-			CreateAt: time.Now(),
+			Client:    cli,
+			UserID:    tgr.UserID,
+			CreateAt:  time.Now(),
+			TokenInfo: ti,
 		}
 		switch rt {
 		case oauth2.Code:
@@ -292,9 +293,10 @@ func (m *Manager) GenerateAccessToken(gt oauth2.GrantType, tgr *oauth2.TokenGene
 	_, ierr := m.injector.Invoke(func(ti oauth2.TokenInfo, gen oauth2.AccessGenerate, stor oauth2.TokenStore) {
 		ti = ti.New()
 		td := &oauth2.GenerateBasic{
-			Client:   cli,
-			UserID:   tgr.UserID,
-			CreateAt: time.Now(),
+			Client:    cli,
+			UserID:    tgr.UserID,
+			CreateAt:  time.Now(),
+			TokenInfo: ti,
 		}
 		gcfg := m.grantConfig(gt)
 
@@ -354,9 +356,10 @@ func (m *Manager) RefreshAccessToken(tgr *oauth2.TokenGenerateRequest) (accessTo
 	oldAccess, oldRefresh := ti.GetAccess(), ti.GetRefresh()
 	_, ierr := m.injector.Invoke(func(stor oauth2.TokenStore, gen oauth2.AccessGenerate) {
 		td := &oauth2.GenerateBasic{
-			Client:   cli,
-			UserID:   ti.GetUserID(),
-			CreateAt: time.Now(),
+			Client:    cli,
+			UserID:    ti.GetUserID(),
+			CreateAt:  time.Now(),
+			TokenInfo: ti,
 		}
 
 		rcfg := DefaultRefreshTokenCfg


### PR DESCRIPTION
Changes:
- Added a field for TokenInfo to the GenerateBasic struct
- Addedthe actual TokenInfo to every creation of GenerateBasic

Reason:
Since an very own implementation of TokenInfo can be set into the manager it makes
much more sense to have that at hand while generating the Auth, Access and RefreshToken.
With this change an issuing of signed JWT is possible.