### PR TITLE
Fix uuid generation

### DIFF
--- a/generates/access.go
+++ b/generates/access.go
@@ -25,10 +25,10 @@ func (ag *AccessGenerate) Token(data *oauth2.GenerateBasic, isGenRefresh bool) (
 	buf.WriteString(data.UserID)
 	buf.WriteString(strconv.FormatInt(data.CreateAt.UnixNano(), 10))
 
-	access = base64.URLEncoding.EncodeToString(uuid.NewV3(uuid.NewV4(), buf.String()).Bytes())
+	access = base64.URLEncoding.EncodeToString(uuid.NewV3(uuid.Must(uuid.NewV4()), buf.String()).Bytes())
 	access = strings.ToUpper(strings.TrimRight(access, "="))
 	if isGenRefresh {
-		refresh = base64.URLEncoding.EncodeToString(uuid.NewV5(uuid.NewV4(), buf.String()).Bytes())
+		refresh = base64.URLEncoding.EncodeToString(uuid.NewV5(uuid.Must(uuid.NewV4()), buf.String()).Bytes())
 		refresh = strings.ToUpper(strings.TrimRight(refresh, "="))
 	}
 

--- a/generates/authorize.go
+++ b/generates/authorize.go
@@ -21,7 +21,7 @@ type AuthorizeGenerate struct{}
 func (ag *AuthorizeGenerate) Token(data *oauth2.GenerateBasic) (code string, err error) {
 	buf := bytes.NewBufferString(data.Client.GetID())
 	buf.WriteString(data.UserID)
-	token := uuid.NewV3(uuid.NewV1(), buf.String())
+	token := uuid.NewV3(uuid.Must(uuid.NewV1()), buf.String())
 	code = base64.URLEncoding.EncodeToString(token.Bytes())
 	code = strings.ToUpper(strings.TrimRight(code, "="))
 

--- a/store/token.go
+++ b/store/token.go
@@ -43,7 +43,7 @@ func (ts *TokenStore) Create(info oauth2.TokenInfo) (err error) {
 			_, _, err = tx.Set(code, string(jv), &buntdb.SetOptions{Expires: true, TTL: info.GetCodeExpiresIn()})
 			return
 		}
-		basicID := uuid.NewV4().String()
+		basicID := uuid.Must(uuid.NewV4()).String()
 		aexp := info.GetAccessExpiresIn()
 		rexp := aexp
 		if refresh := info.GetRefresh(); refresh != "" {


### PR DESCRIPTION
A backwards breaking change has been commit to master in the https://github.com/satori/go.uuid dependency, which has resulted in `gopkg.in/oauth2.v3` no longer being able to compile.

This changes fix that issue in old-style way as described in https://github.com/satori/go.uuid/commit/0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c