### PR TITLE
Initialize TokenInfo before invoking AccessGenerate.Token

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -311,10 +311,6 @@ func (m *Manager) GenerateAccessToken(gt oauth2.GrantType, tgr *oauth2.TokenGene
 			err = terr
 			return
 		}
-		ti.SetClientID(tgr.ClientID)
-		ti.SetUserID(tgr.UserID)
-		ti.SetRedirectURI(tgr.RedirectURI)
-		ti.SetScope(tgr.Scope)
 		ti.SetAccessCreateAt(td.CreateAt)
 		ti.SetAccess(av)
 		// set access token expires

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -293,6 +293,11 @@ func (m *Manager) GenerateAccessToken(gt oauth2.GrantType, tgr *oauth2.TokenGene
 	}
 	_, ierr := m.injector.Invoke(func(ti oauth2.TokenInfo, gen oauth2.AccessGenerate, stor oauth2.TokenStore) {
 		ti = ti.New()
+		ti.SetClientID(tgr.ClientID)
+		ti.SetUserID(tgr.UserID)
+		ti.SetRedirectURI(tgr.RedirectURI)
+		ti.SetScope(tgr.Scope)
+
 		td := &oauth2.GenerateBasic{
 			Client:    cli,
 			UserID:    tgr.UserID,


### PR DESCRIPTION
Use the same code from this commit a305d018

Fixes #51