### PR TITLE
password mode without Client_Secret

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -255,7 +255,7 @@ func (m *Manager) GenerateAccessToken(gt oauth2.GrantType, tgr *oauth2.TokenGene
 	cli, err := m.GetClient(tgr.ClientID)
 	if err != nil {
 		return nil, err
-	} else if tgr.ClientSecret != cli.GetSecret() {
+	} else if tgr.ClientSecret != cli.GetSecret() && gt  != oauth2.PasswordCredentials {
 		return nil, errors.ErrInvalidClient
 	} else if tgr.RedirectURI != "" {
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {


### PR DESCRIPTION
password模式下吗，是不需要传递Client_Secret但是这个还是需要，必须修改源码针对PasswordCredentials模式下进行修改。
已经测试，修改此处后可以通过password模式获取相应的token
规范参考：http://www.ruanyifeng.com/blog/2019/04/oauth-grant-types.html?utm_source=tuicool&utm_medium=referral