### PR TITLE
refresh_token grant doesn't require client creds

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -324,18 +324,16 @@ func (m *Manager) GenerateAccessToken(gt oauth2.GrantType, tgr *oauth2.TokenGene
 
 // RefreshAccessToken refreshing an access token
 func (m *Manager) RefreshAccessToken(tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo, error) {
-	cli, err := m.GetClient(tgr.ClientID)
-	if err != nil {
-		return nil, err
-	} else if tgr.ClientSecret != cli.GetSecret() {
-		return nil, errors.ErrInvalidClient
-	}
-
 	ti, err := m.LoadRefreshToken(tgr.Refresh)
 	if err != nil {
 		return nil, err
-	} else if ti.GetClientID() != tgr.ClientID {
-		return nil, errors.ErrInvalidRefreshToken
+	}
+
+	cli, err := m.GetClient(ti.GetClientID())
+
+	if err != nil {
+		// this shouldn't happen: all refresh tokens should have associated clients
+		return nil, errors.ErrServerError
 	}
 
 	oldAccess, oldRefresh := ti.GetAccess(), ti.GetRefresh()


### PR DESCRIPTION
This is a quick hack to allow for clients that are a hybrid of
confidential and public, where a trusted backend is used for the
authorization code flow while the refresh token (and access token(s))
are stored in a public client (single-page app, CLI, etc).

The proper way to address this would be for the oauth2 library to have
first-class support for public clients, including PKCE. This commit
instead accepts a slight hit to the security posture while making it
possible for such hybrid clients to use the refresh token flow.