### PR TITLE
Removed checks done on ResponseType String()

### DIFF
--- a/const.go
+++ b/const.go
@@ -10,11 +10,7 @@ const (
 )
 
 func (rt ResponseType) String() string {
-	if rt == Code ||
-		rt == Token {
-		return string(rt)
-	}
-	return ""
+	return string(rt)
 }
 
 // GrantType authorization model


### PR DESCRIPTION
There is no need to confirm the value of a type, and it makes it impossible to add additional ResponseType like "id_token"

https://play.golang.org/p/kpd23-n4oQ3 
I'm trying to use this package to host a OIDC server, but the response_type validation always fails as every other 
```
[ResponseType].String() == ""
```