### PR TITLE
add context support

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -17,11 +18,11 @@ type (
 
 	// AuthorizeGenerate generate the authorization code interface
 	AuthorizeGenerate interface {
-		Token(data *GenerateBasic) (code string, err error)
+		Token(ctx context.Context, data *GenerateBasic) (code string, err error)
 	}
 
 	// AccessGenerate generate the access and refresh tokens interface
 	AccessGenerate interface {
-		Token(data *GenerateBasic, isGenRefresh bool) (access, refresh string, err error)
+		Token(ctx context.Context, data *GenerateBasic, isGenRefresh bool) (access, refresh string, err error)
 	}
 )

--- a/generates/access.go
+++ b/generates/access.go
@@ -2,6 +2,7 @@ package generates
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"strconv"
 	"strings"
@@ -20,7 +21,7 @@ type AccessGenerate struct {
 }
 
 // Token based on the UUID generated token
-func (ag *AccessGenerate) Token(data *oauth2.GenerateBasic, isGenRefresh bool) (string, string, error) {
+func (ag *AccessGenerate) Token(ctx context.Context, data *oauth2.GenerateBasic, isGenRefresh bool) (string, string, error) {
 	buf := bytes.NewBufferString(data.Client.GetID())
 	buf.WriteString(data.UserID)
 	buf.WriteString(strconv.FormatInt(data.CreateAt.UnixNano(), 10))

--- a/generates/access_test.go
+++ b/generates/access_test.go
@@ -1,6 +1,7 @@
 package generates_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestAccess(t *testing.T) {
 			CreateAt: time.Now(),
 		}
 		gen := generates.NewAccessGenerate()
-		access, refresh, err := gen.Token(data, true)
+		access, refresh, err := gen.Token(context.Background(), data, true)
 		So(err, ShouldBeNil)
 		So(access, ShouldNotBeEmpty)
 		So(refresh, ShouldNotBeEmpty)

--- a/generates/authorize.go
+++ b/generates/authorize.go
@@ -2,6 +2,7 @@ package generates
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"strings"
 
@@ -18,7 +19,7 @@ func NewAuthorizeGenerate() *AuthorizeGenerate {
 type AuthorizeGenerate struct{}
 
 // Token based on the UUID generated token
-func (ag *AuthorizeGenerate) Token(data *oauth2.GenerateBasic) (string, error) {
+func (ag *AuthorizeGenerate) Token(ctx context.Context, data *oauth2.GenerateBasic) (string, error) {
 	buf := bytes.NewBufferString(data.Client.GetID())
 	buf.WriteString(data.UserID)
 	token := uuid.NewMD5(uuid.Must(uuid.NewRandom()), buf.Bytes())

--- a/generates/authorize_test.go
+++ b/generates/authorize_test.go
@@ -1,6 +1,7 @@
 package generates_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestAuthorize(t *testing.T) {
 			CreateAt: time.Now(),
 		}
 		gen := generates.NewAuthorizeGenerate()
-		code, err := gen.Token(data)
+		code, err := gen.Token(context.Background(), data)
 		So(err, ShouldBeNil)
 		So(code, ShouldNotBeEmpty)
 		Println("\nAuthorize Code:" + code)

--- a/generates/jwt_access.go
+++ b/generates/jwt_access.go
@@ -1,6 +1,7 @@
 package generates
 
 import (
+	"context"
 	"encoding/base64"
 	"strings"
 	"time"
@@ -41,7 +42,7 @@ type JWTAccessGenerate struct {
 }
 
 // Token based on the UUID generated token
-func (a *JWTAccessGenerate) Token(data *oauth2.GenerateBasic, isGenRefresh bool) (string, string, error) {
+func (a *JWTAccessGenerate) Token(ctx context.Context, data *oauth2.GenerateBasic, isGenRefresh bool) (string, string, error) {
 	claims := &JWTAccessClaims{
 		StandardClaims: jwt.StandardClaims{
 			Audience:  data.Client.GetID(),

--- a/generates/jwt_access_test.go
+++ b/generates/jwt_access_test.go
@@ -1,6 +1,7 @@
 package generates_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestJWTAccess(t *testing.T) {
 		}
 
 		gen := generates.NewJWTAccessGenerate([]byte("00000000"), jwt.SigningMethodHS512)
-		access, refresh, err := gen.Token(data, true)
+		access, refresh, err := gen.Token(context.Background(), data, true)
 		So(err, ShouldBeNil)
 		So(access, ShouldNotBeEmpty)
 		So(refresh, ShouldNotBeEmpty)

--- a/manage.go
+++ b/manage.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -21,26 +22,26 @@ type TokenGenerateRequest struct {
 // Manager authorization management interface
 type Manager interface {
 	// get the client information
-	GetClient(clientID string) (cli ClientInfo, err error)
+	GetClient(ctx context.Context, clientID string) (cli ClientInfo, err error)
 
 	// generate the authorization token(code)
-	GenerateAuthToken(rt ResponseType, tgr *TokenGenerateRequest) (authToken TokenInfo, err error)
+	GenerateAuthToken(ctx context.Context, rt ResponseType, tgr *TokenGenerateRequest) (authToken TokenInfo, err error)
 
 	// generate the access token
-	GenerateAccessToken(rt GrantType, tgr *TokenGenerateRequest) (accessToken TokenInfo, err error)
+	GenerateAccessToken(ctx context.Context, rt GrantType, tgr *TokenGenerateRequest) (accessToken TokenInfo, err error)
 
 	// refreshing an access token
-	RefreshAccessToken(tgr *TokenGenerateRequest) (accessToken TokenInfo, err error)
+	RefreshAccessToken(ctx context.Context, tgr *TokenGenerateRequest) (accessToken TokenInfo, err error)
 
 	// use the access token to delete the token information
-	RemoveAccessToken(access string) (err error)
+	RemoveAccessToken(ctx context.Context, access string) (err error)
 
 	// use the refresh token to delete the token information
-	RemoveRefreshToken(refresh string) (err error)
+	RemoveRefreshToken(ctx context.Context, refresh string) (err error)
 
 	// according to the access token for corresponding token information
-	LoadAccessToken(access string) (ti TokenInfo, err error)
+	LoadAccessToken(ctx context.Context, access string) (ti TokenInfo, err error)
 
 	// according to the refresh token for corresponding token information
-	LoadRefreshToken(refresh string) (ti TokenInfo, err error)
+	LoadRefreshToken(ctx context.Context, refresh string) (ti TokenInfo, err error)
 }

--- a/store.go
+++ b/store.go
@@ -1,33 +1,35 @@
 package oauth2
 
+import "context"
+
 type (
 	// ClientStore the client information storage interface
 	ClientStore interface {
 		// according to the ID for the client information
-		GetByID(id string) (ClientInfo, error)
+		GetByID(ctx context.Context, id string) (ClientInfo, error)
 	}
 
 	// TokenStore the token information storage interface
 	TokenStore interface {
 		// create and store the new token information
-		Create(info TokenInfo) error
+		Create(ctx context.Context, info TokenInfo) error
 
 		// delete the authorization code
-		RemoveByCode(code string) error
+		RemoveByCode(ctx context.Context, code string) error
 
 		// use the access token to delete the token information
-		RemoveByAccess(access string) error
+		RemoveByAccess(ctx context.Context, access string) error
 
 		// use the refresh token to delete the token information
-		RemoveByRefresh(refresh string) error
+		RemoveByRefresh(ctx context.Context, refresh string) error
 
 		// use the authorization code for token information data
-		GetByCode(code string) (TokenInfo, error)
+		GetByCode(ctx context.Context, code string) (TokenInfo, error)
 
 		// use the access token for token information data
-		GetByAccess(access string) (TokenInfo, error)
+		GetByAccess(ctx context.Context, access string) (TokenInfo, error)
 
 		// use the refresh token for token information data
-		GetByRefresh(refresh string) (TokenInfo, error)
+		GetByRefresh(ctx context.Context, refresh string) (TokenInfo, error)
 	}
 )

--- a/store/client.go
+++ b/store/client.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -21,7 +22,7 @@ type ClientStore struct {
 }
 
 // GetByID according to the ID for the client information
-func (cs *ClientStore) GetByID(id string) (oauth2.ClientInfo, error) {
+func (cs *ClientStore) GetByID(ctx context.Context, id string) (oauth2.ClientInfo, error) {
 	cs.RLock()
 	defer cs.RUnlock()
 

--- a/store/client_test.go
+++ b/store/client_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"context"
 	"testing"
 
 	"gopkg.in/oauth2.v3/models"
@@ -16,7 +17,7 @@ func TestClientStore(t *testing.T) {
 		err := clientStore.Set("1", &models.Client{ID: "1", Secret: "2"})
 		So(err, ShouldBeNil)
 
-		cli, err := clientStore.GetByID("1")
+		cli, err := clientStore.GetByID(context.Background(), "1")
 		So(err, ShouldBeNil)
 		So(cli.GetID(), ShouldEqual, "1")
 	})

--- a/store/token.go
+++ b/store/token.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -30,7 +31,7 @@ type TokenStore struct {
 }
 
 // Create create and store the new token information
-func (ts *TokenStore) Create(info oauth2.TokenInfo) error {
+func (ts *TokenStore) Create(ctx context.Context, info oauth2.TokenInfo) error {
 	ct := time.Now()
 	jv, err := json.Marshal(info)
 	if err != nil {
@@ -81,17 +82,17 @@ func (ts *TokenStore) remove(key string) error {
 }
 
 // RemoveByCode use the authorization code to delete the token information
-func (ts *TokenStore) RemoveByCode(code string) error {
+func (ts *TokenStore) RemoveByCode(ctx context.Context, code string) error {
 	return ts.remove(code)
 }
 
 // RemoveByAccess use the access token to delete the token information
-func (ts *TokenStore) RemoveByAccess(access string) error {
+func (ts *TokenStore) RemoveByAccess(ctx context.Context, access string) error {
 	return ts.remove(access)
 }
 
 // RemoveByRefresh use the refresh token to delete the token information
-func (ts *TokenStore) RemoveByRefresh(refresh string) error {
+func (ts *TokenStore) RemoveByRefresh(ctx context.Context, refresh string) error {
 	return ts.remove(refresh)
 }
 
@@ -140,12 +141,12 @@ func (ts *TokenStore) getBasicID(key string) (string, error) {
 }
 
 // GetByCode use the authorization code for token information data
-func (ts *TokenStore) GetByCode(code string) (oauth2.TokenInfo, error) {
+func (ts *TokenStore) GetByCode(ctx context.Context, code string) (oauth2.TokenInfo, error) {
 	return ts.getData(code)
 }
 
 // GetByAccess use the access token for token information data
-func (ts *TokenStore) GetByAccess(access string) (oauth2.TokenInfo, error) {
+func (ts *TokenStore) GetByAccess(ctx context.Context, access string) (oauth2.TokenInfo, error) {
 	basicID, err := ts.getBasicID(access)
 	if err != nil {
 		return nil, err
@@ -154,7 +155,7 @@ func (ts *TokenStore) GetByAccess(access string) (oauth2.TokenInfo, error) {
 }
 
 // GetByRefresh use the refresh token for token information data
-func (ts *TokenStore) GetByRefresh(refresh string) (oauth2.TokenInfo, error) {
+func (ts *TokenStore) GetByRefresh(ctx context.Context, refresh string) (oauth2.TokenInfo, error) {
 	basicID, err := ts.getBasicID(refresh)
 	if err != nil {
 		return nil, err

--- a/store/token_test.go
+++ b/store/token_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ func TestTokenStore(t *testing.T) {
 
 func testToken(store oauth2.TokenStore) {
 	Convey("Test authorization code store", func() {
+		ctx := context.Background()
 		info := &models.Token{
 			ClientID:      "1",
 			UserID:        "1_1",
@@ -39,22 +41,23 @@ func testToken(store oauth2.TokenStore) {
 			CodeCreateAt:  time.Now(),
 			CodeExpiresIn: time.Second * 5,
 		}
-		err := store.Create(info)
+		err := store.Create(ctx, info)
 		So(err, ShouldBeNil)
 
-		cinfo, err := store.GetByCode(info.Code)
+		cinfo, err := store.GetByCode(ctx, info.Code)
 		So(err, ShouldBeNil)
 		So(cinfo.GetUserID(), ShouldEqual, info.UserID)
 
-		err = store.RemoveByCode(info.Code)
+		err = store.RemoveByCode(ctx, info.Code)
 		So(err, ShouldBeNil)
 
-		cinfo, err = store.GetByCode(info.Code)
+		cinfo, err = store.GetByCode(ctx, info.Code)
 		So(err, ShouldBeNil)
 		So(cinfo, ShouldBeNil)
 	})
 
 	Convey("Test access token store", func() {
+		ctx := context.Background()
 		info := &models.Token{
 			ClientID:        "1",
 			UserID:          "1_1",
@@ -64,22 +67,23 @@ func testToken(store oauth2.TokenStore) {
 			AccessCreateAt:  time.Now(),
 			AccessExpiresIn: time.Second * 5,
 		}
-		err := store.Create(info)
+		err := store.Create(ctx, info)
 		So(err, ShouldBeNil)
 
-		ainfo, err := store.GetByAccess(info.GetAccess())
+		ainfo, err := store.GetByAccess(ctx, info.GetAccess())
 		So(err, ShouldBeNil)
 		So(ainfo.GetUserID(), ShouldEqual, info.GetUserID())
 
-		err = store.RemoveByAccess(info.GetAccess())
+		err = store.RemoveByAccess(ctx, info.GetAccess())
 		So(err, ShouldBeNil)
 
-		ainfo, err = store.GetByAccess(info.GetAccess())
+		ainfo, err = store.GetByAccess(ctx, info.GetAccess())
 		So(err, ShouldBeNil)
 		So(ainfo, ShouldBeNil)
 	})
 
 	Convey("Test refresh token store", func() {
+		ctx := context.Background()
 		info := &models.Token{
 			ClientID:         "1",
 			UserID:           "1_2",
@@ -92,22 +96,23 @@ func testToken(store oauth2.TokenStore) {
 			RefreshCreateAt:  time.Now(),
 			RefreshExpiresIn: time.Second * 15,
 		}
-		err := store.Create(info)
+		err := store.Create(ctx, info)
 		So(err, ShouldBeNil)
 
-		rinfo, err := store.GetByRefresh(info.GetRefresh())
+		rinfo, err := store.GetByRefresh(ctx, info.GetRefresh())
 		So(err, ShouldBeNil)
 		So(rinfo.GetUserID(), ShouldEqual, info.GetUserID())
 
-		err = store.RemoveByRefresh(info.GetRefresh())
+		err = store.RemoveByRefresh(ctx, info.GetRefresh())
 		So(err, ShouldBeNil)
 
-		rinfo, err = store.GetByRefresh(info.GetRefresh())
+		rinfo, err = store.GetByRefresh(ctx, info.GetRefresh())
 		So(err, ShouldBeNil)
 		So(rinfo, ShouldBeNil)
 	})
 
 	Convey("Test TTL", func() {
+		ctx := context.Background()
 		info := &models.Token{
 			ClientID:         "1",
 			UserID:           "1_1",
@@ -120,14 +125,14 @@ func testToken(store oauth2.TokenStore) {
 			RefreshCreateAt:  time.Now(),
 			RefreshExpiresIn: time.Second * 1,
 		}
-		err := store.Create(info)
+		err := store.Create(ctx, info)
 		So(err, ShouldBeNil)
 
 		time.Sleep(time.Second * 1)
-		ainfo, err := store.GetByAccess(info.Access)
+		ainfo, err := store.GetByAccess(ctx, info.Access)
 		So(err, ShouldBeNil)
 		So(ainfo, ShouldBeNil)
-		rinfo, err := store.GetByRefresh(info.Refresh)
+		rinfo, err := store.GetByRefresh(ctx, info.Refresh)
 		So(err, ShouldBeNil)
 		So(rinfo, ShouldBeNil)
 	})


### PR DESCRIPTION
Context support is a must-have these days. The buntdb doesn't seem to support context but other databases do, such as Redis, MySQL, etc.

This diff adds context support.

Test plan:
1. Unit tests are passing
2. Manually compiled `example` server and client and run manual test

Original issue: #65 