### PR TITLE
Allows client to use custom password verification

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -256,9 +256,15 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 	cli, err := m.GetClient(ctx, tgr.ClientID)
 	if err != nil {
 		return nil, err
+	}
+	if cliPass, ok := cli.(oauth2.ClientPasswordVerifier); ok {
+		if !cliPass.VerifyPassword(tgr.ClientSecret) {
+			return nil, errors.ErrInvalidClient
+		}
 	} else if tgr.ClientSecret != cli.GetSecret() {
 		return nil, errors.ErrInvalidClient
-	} else if tgr.RedirectURI != "" {
+	}
+	if tgr.RedirectURI != "" {
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {
 			return nil, err
 		}

--- a/model.go
+++ b/model.go
@@ -13,6 +13,11 @@ type (
 		GetUserID() string
 	}
 
+	// ClientPasswordVerifier the password handler interface
+	ClientPasswordVerifier interface {
+		VerifyPassword(string) bool
+	}
+
 	// TokenInfo the token information model interface
 	TokenInfo interface {
 		New() TokenInfo


### PR DESCRIPTION
It is not secure to use plain passwords and a way to handle custom password hashes is a must.

This diff would allow something like this to work with bcrypt and other hashing methods:

```go
import "golang.org/x/crypto/bcrypt"

type MyClient struct {
	models.Client
}

func (c *MyClient) VerifyPassword(password string) bool {
	err := bcrypt.CompareHashAndPassword([]byte(password), []byte(c.GetSecret()))
	return err == nil
}
```

Closes #108