### PR TITLE
Rfc6749 4.1.3 - client_secret isn't required

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -261,7 +261,7 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if !cliPass.VerifyPassword(tgr.ClientSecret) {
 			return nil, errors.ErrInvalidClient
 		}
-	} else if tgr.ClientSecret != cli.GetSecret() {
+	} else if len(tgr.ClientSecret) > 0 && tgr.ClientSecret != cli.GetSecret() {
 		return nil, errors.ErrInvalidClient
 	}
 	if tgr.RedirectURI != "" {

--- a/server/handler.go
+++ b/server/handler.go
@@ -46,10 +46,10 @@ type (
 // ClientFormHandler get client data from form
 func ClientFormHandler(r *http.Request) (string, string, error) {
 	clientID := r.Form.Get("client_id")
-	clientSecret := r.Form.Get("client_secret")
-	if clientID == "" || clientSecret == "" {
+	if clientID == "" {
 		return "", "", errors.ErrInvalidClient
 	}
+	clientSecret := r.Form.Get("client_secret")
 	return clientID, clientSecret, nil
 }
 


### PR DESCRIPTION
Resubmission of https://github.com/go-oauth2/oauth2/pull/151 it seems it was an issue caused by line terminators.