### PR TITLE
Fix client secret not being checked

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -261,7 +261,7 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if !cliPass.VerifyPassword(tgr.ClientSecret) {
 			return nil, errors.ErrInvalidClient
 		}
-	} else if len(tgr.ClientSecret) > 0 && tgr.ClientSecret != cli.GetSecret() {
+	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
 		return nil, errors.ErrInvalidClient
 	}
 	if tgr.RedirectURI != "" {


### PR DESCRIPTION
See #156 

Essentially this PR does change the condition for the secret check. Before it would only see if the secret was submitted, now it sees if the client has a secret.