### PR TITLE
fix server.go:243:6: no new variables on left side of :=

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -240,7 +240,7 @@ func (s *Server) GetAuthorizeToken(ctx context.Context, req *AuthorizeRequest) (
 		}
 	}
 
-	tgr := &oauth2.TokenGenerateRequest{
+	tgr = &oauth2.TokenGenerateRequest{
 		ClientID:            req.ClientID,
 		UserID:              req.UserID,
 		RedirectURI:         req.RedirectURI,


### PR DESCRIPTION
redefine tgr