### PR TITLE
fixed the bug to compare client secrets when refreshing token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ _testmain.go
 *.test
 *.prof
 
+coverage.txt
+
 # OSX
 *.DS_Store
 *.db

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -363,6 +363,10 @@ func (m *Manager) RefreshAccessToken(ctx context.Context, tgr *oauth2.TokenGener
 	cli, err := m.GetClient(ctx, tgr.ClientID)
 	if err != nil {
 		return nil, err
+	} else if cliPass, ok := cli.(oauth2.ClientPasswordVerifier); ok {
+		if !cliPass.VerifyPassword(tgr.ClientSecret) {
+			return nil, errors.ErrInvalidClient
+		}
 	} else if tgr.ClientSecret != cli.GetSecret() {
 		return nil, errors.ErrInvalidClient
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -240,7 +240,7 @@ func (s *Server) GetAuthorizeToken(ctx context.Context, req *AuthorizeRequest) (
 		}
 	}
 
-	tgr := &oauth2.TokenGenerateRequest{
+	tgr = &oauth2.TokenGenerateRequest{
 		ClientID:            req.ClientID,
 		UserID:              req.UserID,
 		RedirectURI:         req.RedirectURI,


### PR DESCRIPTION
This PR fixed the client secret check using the same approach for authorization. It also fixed the compilation error on server.go line 243.