### PR TITLE
modifed the implementation of the refresh token process

### DIFF
--- a/manage/manage_test.go
+++ b/manage/manage_test.go
@@ -93,9 +93,11 @@ func testManager(tgr *oauth2.TokenGenerateRequest, manager oauth2.Manager) {
 	So(err, ShouldBeNil)
 	So(rinfo.GetClientID(), ShouldEqual, atParams.ClientID)
 
-	atParams.Refresh = refreshToken
-	atParams.Scope = "owner"
-	rti, err := manager.RefreshAccessToken(ctx, atParams)
+	refreshParams := &oauth2.TokenGenerateRequest{
+		Refresh: refreshToken,
+		Scope:   "owner",
+	}
+	rti, err := manager.RefreshAccessToken(ctx, refreshParams)
 	So(err, ShouldBeNil)
 
 	refreshAT := rti.GetAccess()

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -360,22 +360,14 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 
 // RefreshAccessToken refreshing an access token
 func (m *Manager) RefreshAccessToken(ctx context.Context, tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo, error) {
-	cli, err := m.GetClient(ctx, tgr.ClientID)
-	if err != nil {
-		return nil, err
-	} else if cliPass, ok := cli.(oauth2.ClientPasswordVerifier); ok {
-		if !cliPass.VerifyPassword(tgr.ClientSecret) {
-			return nil, errors.ErrInvalidClient
-		}
-	} else if tgr.ClientSecret != cli.GetSecret() {
-		return nil, errors.ErrInvalidClient
-	}
-
 	ti, err := m.LoadRefreshToken(ctx, tgr.Refresh)
 	if err != nil {
 		return nil, err
-	} else if ti.GetClientID() != tgr.ClientID {
-		return nil, errors.ErrInvalidRefreshToken
+	}
+
+	cli, err := m.GetClient(ctx, ti.GetClientID())
+	if err != nil {
+		return nil, err
 	}
 
 	oldAccess, oldRefresh := ti.GetAccess(), ti.GetRefresh()


### PR DESCRIPTION
to meet the rfc6749 guidelines.
https://datatracker.ietf.org/doc/html/rfc6749#section-6

rfc6749 section 6 mentions only "refresh_token" and "grant_type" are REQUIRED,
while the previous implementation requires "client_id" and "client_secret".