### PR TITLE
Handle invalid code challenge methods

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,7 @@ func (s *Server) ValidationAuthorizeRequest(r *http.Request) (*AuthorizeRequest,
 	if ccm == "" {
 		ccm = oauth2.CodeChallengePlain
 	}
-	if ccm.String() != "" && !s.CheckCodeChallengeMethod(ccm) {
+	if ccm != "" && !s.CheckCodeChallengeMethod(ccm) {
 		return nil, errors.ErrUnsupportedCodeChallengeMethod
 	}
 


### PR DESCRIPTION
If invalid code challenge method (for example, `code_challenge_method=invalid`) is specified in Authorize request, it was not checked since `ccm.String()` returned empty string for unknown methods - the request was allowed to pass through.

This fix checks for empty code challenge method thus enabling the verification for invalid code challenge methods.