### PR TITLE
Added an error handler that is invoked before s.redirectError

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -36,6 +36,9 @@ type (
 	// InternalErrorHandler internal error handing
 	InternalErrorHandler func(err error) (re *errors.Response)
 
+	// PreRedirectErrorHandler is used to override "redirect-on-error" behavior
+	PreRedirectErrorHandler func(w http.ResponseWriter, req *AuthorizeRequest, err error) error
+
 	// AuthorizeScopeHandler set the authorized scope
 	AuthorizeScopeHandler func(w http.ResponseWriter, r *http.Request) (scope string, err error)
 

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -59,7 +59,6 @@ func (s *Server) SetRefreshingValidationHandler(handler RefreshingValidationHand
 	s.RefreshingValidationHandler = handler
 }
 
-
 // SetResponseErrorHandler response error handling
 func (s *Server) SetResponseErrorHandler(handler ResponseErrorHandler) {
 	s.ResponseErrorHandler = handler
@@ -68,6 +67,11 @@ func (s *Server) SetResponseErrorHandler(handler ResponseErrorHandler) {
 // SetInternalErrorHandler internal error handling
 func (s *Server) SetInternalErrorHandler(handler InternalErrorHandler) {
 	s.InternalErrorHandler = handler
+}
+
+// SetPreRedirectErrorHandler sets the PreRedirectErrorHandler in current Server instance
+func (s *Server) SetPreRedirectErrorHandler(handler PreRedirectErrorHandler) {
+	s.PreRedirectErrorHandler = handler
 }
 
 // SetExtensionFieldsHandler in response to the access token with the extension of the field


### PR DESCRIPTION
This PR adds a mechanism that can be used to override the default error handling behavior implemented by `s.redirectError`. The error handler of this mechanism is defined as `func(rw http.ResponseWriter, req *server.AuthorizeRequest, error error) error`, and can be enabled by passing a non-nil function to `SetPreRedirectErrorHandler`.