### PR TITLE
Per client authorization

### DIFF
--- a/example/server/server.go
+++ b/example/server/server.go
@@ -64,7 +64,7 @@ func main() {
 
 	srv := server.NewServer(server.NewConfig(), manager)
 
-	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, username, password string) (userID string, err error) {
+	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, username, password, clientID string) (userID string, err error) {
 		if username == "test" && password == "test" {
 			userID = "test"
 		}

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -64,7 +64,7 @@ func main() {
 
 	srv := server.NewServer(server.NewConfig(), manager)
 
-	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, username, password, clientID string) (userID string, err error) {
+	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, clientID, username, password string) (userID string, err error) {
 		if username == "test" && password == "test" {
 			userID = "test"
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -23,7 +23,7 @@ type (
 	UserAuthorizationHandler func(w http.ResponseWriter, r *http.Request) (userID string, err error)
 
 	// PasswordAuthorizationHandler get user id from username and password
-	PasswordAuthorizationHandler func(ctx context.Context, username, password string) (userID string, err error)
+	PasswordAuthorizationHandler func(ctx context.Context, username, password, clientID string) (userID string, err error)
 
 	// RefreshingScopeHandler check the scope of the refreshing token
 	RefreshingScopeHandler func(tgr *oauth2.TokenGenerateRequest, oldScope string) (allowed bool, err error)

--- a/server/handler.go
+++ b/server/handler.go
@@ -23,7 +23,7 @@ type (
 	UserAuthorizationHandler func(w http.ResponseWriter, r *http.Request) (userID string, err error)
 
 	// PasswordAuthorizationHandler get user id from username and password
-	PasswordAuthorizationHandler func(ctx context.Context, username, password, clientID string) (userID string, err error)
+	PasswordAuthorizationHandler func(ctx context.Context, clientID, username, password string) (userID string, err error)
 
 	// RefreshingScopeHandler check the scope of the refreshing token
 	RefreshingScopeHandler func(tgr *oauth2.TokenGenerateRequest, oldScope string) (allowed bool, err error)

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ func NewServer(cfg *Config, manager oauth2.Manager) *Server {
 		return "", errors.ErrAccessDenied
 	}
 
-	srv.PasswordAuthorizationHandler = func(ctx context.Context, clientID, username, password string) (string, error) {
+	srv.PasswordAuthorizationHandler = func(ctx context.Context, username, password, clientID string) (string, error) {
 		return "", errors.ErrAccessDenied
 	}
 	return srv

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ func NewServer(cfg *Config, manager oauth2.Manager) *Server {
 		return "", errors.ErrAccessDenied
 	}
 
-	srv.PasswordAuthorizationHandler = func(ctx context.Context, username, password, clientID string) (string, error) {
+	srv.PasswordAuthorizationHandler = func(ctx context.Context, clientID, username, password string) (string, error) {
 		return "", errors.ErrAccessDenied
 	}
 	return srv

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ func NewServer(cfg *Config, manager oauth2.Manager) *Server {
 		return "", errors.ErrAccessDenied
 	}
 
-	srv.PasswordAuthorizationHandler = func(ctx context.Context, username, password string) (string, error) {
+	srv.PasswordAuthorizationHandler = func(ctx context.Context, clientID, username, password string) (string, error) {
 		return "", errors.ErrAccessDenied
 	}
 	return srv
@@ -357,7 +357,7 @@ func (s *Server) ValidationTokenRequest(r *http.Request) (oauth2.GrantType, *oau
 			return "", nil, errors.ErrInvalidRequest
 		}
 
-		userID, err := s.PasswordAuthorizationHandler(r.Context(), username, password)
+		userID, err := s.PasswordAuthorizationHandler(r.Context(), username, password, clientID)
 		if err != nil {
 			return "", nil, err
 		} else if userID == "" {

--- a/server/server.go
+++ b/server/server.go
@@ -357,7 +357,7 @@ func (s *Server) ValidationTokenRequest(r *http.Request) (oauth2.GrantType, *oau
 			return "", nil, errors.ErrInvalidRequest
 		}
 
-		userID, err := s.PasswordAuthorizationHandler(r.Context(), username, password, clientID)
+		userID, err := s.PasswordAuthorizationHandler(r.Context(), clientID, username, password)
 		if err != nil {
 			return "", nil, err
 		} else if userID == "" {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -251,7 +251,7 @@ func TestPasswordCredentials(t *testing.T) {
 
 	manager.MapClientStorage(clientStore(""))
 	srv = server.NewDefaultServer(manager)
-	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, username, password string) (userID string, err error) {
+	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, username, password, clientID string) (userID string, err error) {
 		if username == "admin" && password == "123456" {
 			userID = "000000"
 			return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -251,7 +251,7 @@ func TestPasswordCredentials(t *testing.T) {
 
 	manager.MapClientStorage(clientStore(""))
 	srv = server.NewDefaultServer(manager)
-	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, username, password, clientID string) (userID string, err error) {
+	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, clientID, username, password string) (userID string, err error) {
 		if username == "admin" && password == "123456" {
 			userID = "000000"
 			return


### PR DESCRIPTION
Just add `clientID` in `PasswordAuthorizationHandler` if we need to customize password authorization per client.
