### PR TITLE
fix server_test.go so it works + make code flow test pass with no secret

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -290,7 +290,7 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
 		// auth code flow doesnt require client_secret if used with PKCE and state parameter
 		// this is especially useful for mobile apps, that cant hold the secret
-		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && tgr.CodeVerifier != "") {
+		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && len(tgr.CodeVerifier) >= 43) {
 			return nil, errors.ErrInvalidClient
 		}
 	}

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -290,7 +290,7 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
 		// auth code flow doesnt require client_secret if used with PKCE and state parameter
 		// this is especially useful for mobile apps, that cant hold the secret
-		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && len(tgr.CodeVerifier) >= 43) {
+		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && tgr.CodeVerifier != "") {
 			return nil, errors.ErrInvalidClient
 		}
 	}

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -287,8 +287,12 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if !cliPass.VerifyPassword(tgr.ClientSecret) {
 			return nil, errors.ErrInvalidClient
 		}
-	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() && !(gt.String() == oauth2.AuthorizationCode.String() && tgr.ClientSecret == "") {
-		return nil, errors.ErrInvalidClient
+	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
+		// auth code flow doesnt require client_secret if used with PKCE and state parameter
+		// this is especially useful for mobile apps, that cant hold the secret
+		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && tgr.CodeVerifier != "") {
+			return nil, errors.ErrInvalidClient
+		}
 	}
 	if tgr.RedirectURI != "" {
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -218,7 +218,7 @@ func (m *Manager) GenerateAuthToken(ctx context.Context, rt oauth2.ResponseType,
 	}
 	return ti, nil
 }
- 
+
 // get authorization code data
 func (m *Manager) getAuthorizationCode(ctx context.Context, code string) (oauth2.TokenInfo, error) {
 	ti, err := m.tokenStore.GetByCode(ctx, code)
@@ -287,7 +287,7 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if !cliPass.VerifyPassword(tgr.ClientSecret) {
 			return nil, errors.ErrInvalidClient
 		}
-	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
+	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() && !(gt.String() == oauth2.AuthorizationCode.String() && tgr.ClientSecret == "") {
 		return nil, errors.ErrInvalidClient
 	}
 	if tgr.RedirectURI != "" {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/gavv/httpexpect"
@@ -107,7 +106,7 @@ func TestAuthorizeCode(t *testing.T) {
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		Expect().Status(http.StatusOK)
 }
 
@@ -134,7 +133,7 @@ func TestAuthorizeCodeWithChallengePlain(t *testing.T) {
 				WithFormField("grant_type", "authorization_code").
 				WithFormField("client_id", clientID).
 				WithFormField("code", code).
-				WithBasicAuth("code_verifier", "testchallenge").
+				WithFormField("code_verifier", plainChallenge).
 				Expect().
 				Status(http.StatusOK).
 				JSON().Object()
@@ -152,13 +151,14 @@ func TestAuthorizeCodeWithChallengePlain(t *testing.T) {
 		userID = "000000"
 		return
 	})
+	srv.SetClientInfoHandler(server.ClientFormHandler)
 
 	e.GET("/authorize").
 		WithQuery("response_type", "code").
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		WithQuery("code_challenge", plainChallenge).
 		Expect().Status(http.StatusOK)
 }
@@ -186,7 +186,7 @@ func TestAuthorizeCodeWithChallengeS256(t *testing.T) {
 				WithFormField("grant_type", "authorization_code").
 				WithFormField("client_id", clientID).
 				WithFormField("code", code).
-				WithBasicAuth("code_verifier", s256Challenge).
+				WithFormField("code_verifier", s256Challenge).
 				Expect().
 				Status(http.StatusOK).
 				JSON().Object()
@@ -204,13 +204,14 @@ func TestAuthorizeCodeWithChallengeS256(t *testing.T) {
 		userID = "000000"
 		return
 	})
+	srv.SetClientInfoHandler(server.ClientFormHandler)
 
 	e.GET("/authorize").
 		WithQuery("response_type", "code").
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		WithQuery("code_challenge", s256ChallengeHash).
 		WithQuery("code_challenge_method", "S256").
 		Expect().Status(http.StatusOK)
@@ -238,7 +239,7 @@ func TestImplicit(t *testing.T) {
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		Expect().Status(http.StatusOK)
 }
 
@@ -384,7 +385,7 @@ func TestRefreshing(t *testing.T) {
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		Expect().Status(http.StatusOK)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,9 +25,10 @@ var (
 	clientSecret = "11111111"
 
 	plainChallenge = "ThisIsAFourtyThreeCharactersLongStringThing"
-	s256Challenge  = "s256test"
-	// echo s256test | sha256 | base64 | tr '/+' '_-'
-	s256ChallengeHash = "W6YWc_4yHwYN-cGDgGmOMHF3l7KDy7VcRjf7q2FVF-o="
+	s256Challenge  = "s256tests256tests256tests256tests256tests256test"
+	// sha2562 := sha256.Sum256([]byte(s256Challenge))
+	// fmt.Printf(base64.URLEncoding.EncodeToString(sha2562[:]))
+	s256ChallengeHash = "To2Xqv01cm16bC9Sf7KRRS8CO2SFss_HSMQOr3sdCDE="
 )
 
 func init() {


### PR DESCRIPTION
1. Remove query encoding of urls for redirect uri in server_test.go to make tests successfully hit the /oauth2 callback endpoint
2. Then fix the token requests in the auth code flow tests
3. Then fix the manager to allow for no client_secret for auth code flow with pkce where code verifier is at least 43 chars. EDIT: i see there might not be need to check its length and only its existence. Its already validated properly. Merely checking that that code verifier is not empty string will be enough to ensure that the request will fail without the proper code verifier. 

- [x] Remove length check on code verifier and only check if its a non-empty string
- [ ] actually we need to differentiate between confidential and public clients, which this server library cannot, afaik. EDIT: new draft PR here https://github.com/go-oauth2/oauth2/pull/233

the pkce spec states that code verifier should be minimum 43 chars (https://github.com/go-oauth2/oauth2/pull/230#issuecomment-1396556389), should this be verified earlier in the process?