### PR TITLE
Introducing public field to client models

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -218,7 +218,7 @@ func (m *Manager) GenerateAuthToken(ctx context.Context, rt oauth2.ResponseType,
 	}
 	return ti, nil
 }
- 
+
 // get authorization code data
 func (m *Manager) getAuthorizationCode(ctx context.Context, code string) (oauth2.TokenInfo, error) {
 	ti, err := m.tokenStore.GetByCode(ctx, code)
@@ -288,7 +288,11 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 			return nil, errors.ErrInvalidClient
 		}
 	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
-		return nil, errors.ErrInvalidClient
+		// auth code flow doesnt require client_secret if used with PKCE and state parameter
+		// this is especially useful for mobile apps, that cant hold the secret
+		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && tgr.CodeVerifier != "") {
+			return nil, errors.ErrInvalidClient
+		}
 	}
 	if tgr.RedirectURI != "" {
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -287,12 +287,8 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if !cliPass.VerifyPassword(tgr.ClientSecret) {
 			return nil, errors.ErrInvalidClient
 		}
-	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
-		// auth code flow doesnt require client_secret if used with PKCE and state parameter
-		// this is especially useful for mobile apps, that cant hold the secret
-		if !(gt == oauth2.AuthorizationCode && tgr.ClientSecret == "" && tgr.CodeVerifier != "") {
-			return nil, errors.ErrInvalidClient
-		}
+	} else if cli.IsPublic() == false && len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
+		return nil, errors.ErrInvalidClient
 	}
 	if tgr.RedirectURI != "" {
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -287,13 +287,17 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if !cliPass.VerifyPassword(tgr.ClientSecret) {
 			return nil, errors.ErrInvalidClient
 		}
-	} else if cli.IsPublic() == false && len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
+	} else if len(cli.GetSecret()) > 0 && tgr.ClientSecret != cli.GetSecret() {
 		return nil, errors.ErrInvalidClient
 	}
 	if tgr.RedirectURI != "" {
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {
 			return nil, err
 		}
+	}
+
+	if gt == oauth2.ClientCredentials && cli.IsPublic() == true {
+		return nil, errors.ErrInvalidClient
 	}
 
 	if gt == oauth2.AuthorizationCode {

--- a/model.go
+++ b/model.go
@@ -10,6 +10,7 @@ type (
 		GetID() string
 		GetSecret() string
 		GetDomain() string
+		IsPublic() bool
 		GetUserID() string
 	}
 

--- a/models/client.go
+++ b/models/client.go
@@ -5,6 +5,7 @@ type Client struct {
 	ID     string
 	Secret string
 	Domain string
+	Public bool
 	UserID string
 }
 
@@ -21,6 +22,11 @@ func (c *Client) GetSecret() string {
 // GetDomain client domain
 func (c *Client) GetDomain() string {
 	return c.Domain
+}
+
+// GetUserID user id
+func (c *Client) IsPublic() bool {
+	return c.Public
 }
 
 // GetUserID user id

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -38,9 +38,15 @@ func init() {
 
 func clientStore(domain string, public bool) oauth2.ClientStore {
 	clientStore := store.NewClientStore()
+	var secret string
+	if public {
+		secret = ""
+	} else {
+		secret = clientSecret
+	}
 	clientStore.Set(clientID, &models.Client{
 		ID:     clientID,
-		Secret: clientSecret,
+		Secret: secret,
 		Domain: domain,
 		Public: public,
 	})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/gavv/httpexpect"
@@ -26,9 +25,10 @@ var (
 	clientSecret = "11111111"
 
 	plainChallenge = "ThisIsAFourtyThreeCharactersLongStringThing"
-	s256Challenge  = "s256test"
-	// echo s256test | sha256 | base64 | tr '/+' '_-'
-	s256ChallengeHash = "W6YWc_4yHwYN-cGDgGmOMHF3l7KDy7VcRjf7q2FVF-o="
+	s256Challenge  = "s256tests256tests256tests256tests256tests256test"
+	// sha2562 := sha256.Sum256([]byte(s256Challenge))
+	// fmt.Printf(base64.URLEncoding.EncodeToString(sha2562[:]))
+	s256ChallengeHash = "To2Xqv01cm16bC9Sf7KRRS8CO2SFss_HSMQOr3sdCDE="
 )
 
 func init() {
@@ -107,7 +107,7 @@ func TestAuthorizeCode(t *testing.T) {
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		Expect().Status(http.StatusOK)
 }
 
@@ -134,7 +134,7 @@ func TestAuthorizeCodeWithChallengePlain(t *testing.T) {
 				WithFormField("grant_type", "authorization_code").
 				WithFormField("client_id", clientID).
 				WithFormField("code", code).
-				WithBasicAuth("code_verifier", "testchallenge").
+				WithFormField("code_verifier", plainChallenge).
 				Expect().
 				Status(http.StatusOK).
 				JSON().Object()
@@ -152,13 +152,14 @@ func TestAuthorizeCodeWithChallengePlain(t *testing.T) {
 		userID = "000000"
 		return
 	})
+	srv.SetClientInfoHandler(server.ClientFormHandler)
 
 	e.GET("/authorize").
 		WithQuery("response_type", "code").
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		WithQuery("code_challenge", plainChallenge).
 		Expect().Status(http.StatusOK)
 }
@@ -186,7 +187,7 @@ func TestAuthorizeCodeWithChallengeS256(t *testing.T) {
 				WithFormField("grant_type", "authorization_code").
 				WithFormField("client_id", clientID).
 				WithFormField("code", code).
-				WithBasicAuth("code_verifier", s256Challenge).
+				WithFormField("code_verifier", s256Challenge).
 				Expect().
 				Status(http.StatusOK).
 				JSON().Object()
@@ -204,13 +205,14 @@ func TestAuthorizeCodeWithChallengeS256(t *testing.T) {
 		userID = "000000"
 		return
 	})
+	srv.SetClientInfoHandler(server.ClientFormHandler)
 
 	e.GET("/authorize").
 		WithQuery("response_type", "code").
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		WithQuery("code_challenge", s256ChallengeHash).
 		WithQuery("code_challenge_method", "S256").
 		Expect().Status(http.StatusOK)
@@ -238,7 +240,7 @@ func TestImplicit(t *testing.T) {
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		Expect().Status(http.StatusOK)
 }
 
@@ -384,7 +386,7 @@ func TestRefreshing(t *testing.T) {
 		WithQuery("client_id", clientID).
 		WithQuery("scope", "all").
 		WithQuery("state", "123").
-		WithQuery("redirect_uri", url.QueryEscape(csrv.URL+"/oauth2")).
+		WithQuery("redirect_uri", csrv.URL+"/oauth2").
 		Expect().Status(http.StatusOK)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,12 +36,13 @@ func init() {
 	manager.MustTokenStorage(store.NewMemoryTokenStore())
 }
 
-func clientStore(domain string) oauth2.ClientStore {
+func clientStore(domain string, public bool) oauth2.ClientStore {
 	clientStore := store.NewClientStore()
 	clientStore.Set(clientID, &models.Client{
 		ID:     clientID,
 		Secret: clientSecret,
 		Domain: domain,
+		Public: public,
 	})
 	return clientStore
 }
@@ -95,7 +96,7 @@ func TestAuthorizeCode(t *testing.T) {
 	}))
 	defer csrv.Close()
 
-	manager.MapClientStorage(clientStore(csrv.URL))
+	manager.MapClientStorage(clientStore(csrv.URL, true))
 	srv = server.NewDefaultServer(manager)
 	srv.SetUserAuthorizationHandler(func(w http.ResponseWriter, r *http.Request) (userID string, err error) {
 		userID = "000000"
@@ -146,7 +147,7 @@ func TestAuthorizeCodeWithChallengePlain(t *testing.T) {
 	}))
 	defer csrv.Close()
 
-	manager.MapClientStorage(clientStore(csrv.URL))
+	manager.MapClientStorage(clientStore(csrv.URL, true))
 	srv = server.NewDefaultServer(manager)
 	srv.SetUserAuthorizationHandler(func(w http.ResponseWriter, r *http.Request) (userID string, err error) {
 		userID = "000000"
@@ -199,7 +200,7 @@ func TestAuthorizeCodeWithChallengeS256(t *testing.T) {
 	}))
 	defer csrv.Close()
 
-	manager.MapClientStorage(clientStore(csrv.URL))
+	manager.MapClientStorage(clientStore(csrv.URL, true))
 	srv = server.NewDefaultServer(manager)
 	srv.SetUserAuthorizationHandler(func(w http.ResponseWriter, r *http.Request) (userID string, err error) {
 		userID = "000000"
@@ -228,7 +229,7 @@ func TestImplicit(t *testing.T) {
 	csrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer csrv.Close()
 
-	manager.MapClientStorage(clientStore(csrv.URL))
+	manager.MapClientStorage(clientStore(csrv.URL, false))
 	srv = server.NewDefaultServer(manager)
 	srv.SetUserAuthorizationHandler(func(w http.ResponseWriter, r *http.Request) (userID string, err error) {
 		userID = "000000"
@@ -251,7 +252,7 @@ func TestPasswordCredentials(t *testing.T) {
 	defer tsrv.Close()
 	e := httpexpect.New(t, tsrv.URL)
 
-	manager.MapClientStorage(clientStore(""))
+	manager.MapClientStorage(clientStore("", false))
 	srv = server.NewDefaultServer(manager)
 	srv.SetPasswordAuthorizationHandler(func(ctx context.Context, clientID, username, password string) (userID string, err error) {
 		if username == "admin" && password == "123456" {
@@ -284,7 +285,7 @@ func TestClientCredentials(t *testing.T) {
 	defer tsrv.Close()
 	e := httpexpect.New(t, tsrv.URL)
 
-	manager.MapClientStorage(clientStore(""))
+	manager.MapClientStorage(clientStore("", false))
 
 	srv = server.NewDefaultServer(manager)
 	srv.SetClientInfoHandler(server.ClientFormHandler)
@@ -374,7 +375,7 @@ func TestRefreshing(t *testing.T) {
 	}))
 	defer csrv.Close()
 
-	manager.MapClientStorage(clientStore(csrv.URL))
+	manager.MapClientStorage(clientStore(csrv.URL, true))
 	srv = server.NewDefaultServer(manager)
 	srv.SetUserAuthorizationHandler(func(w http.ResponseWriter, r *http.Request) (userID string, err error) {
 		userID = "000000"


### PR DESCRIPTION
1. denying client credentials grant if client is public
2. adjusting tests to make different clients based on whether or not they are public
3. this will allow for using public grants like authorisation code flow with client_secret not set on client and Public set to true
4. if libraries implement this and dont want to care about it they can just return false for IsPublic