### PR TITLE
ClientBasicHandler should url.QueryUnescape client data

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1,73 +1,85 @@
 package server
 
 import (
-	"context"
-	"net/http"
-	"time"
+    "context"
+    "net/http"
+    "net/url"
+    "time"
 
-	"github.com/go-oauth2/oauth2/v4"
-	"github.com/go-oauth2/oauth2/v4/errors"
+    "github.com/go-oauth2/oauth2/v4"
+    "github.com/go-oauth2/oauth2/v4/errors"
 )
 
 type (
-	// ClientInfoHandler get client info from request
-	ClientInfoHandler func(r *http.Request) (clientID, clientSecret string, err error)
+    // ClientInfoHandler get client info from request
+    ClientInfoHandler func(r *http.Request) (clientID, clientSecret string, err error)
 
-	// ClientAuthorizedHandler check the client allows to use this authorization grant type
-	ClientAuthorizedHandler func(clientID string, grant oauth2.GrantType) (allowed bool, err error)
+    // ClientAuthorizedHandler check the client allows to use this authorization grant type
+    ClientAuthorizedHandler func(clientID string, grant oauth2.GrantType) (allowed bool, err error)
 
-	// ClientScopeHandler check the client allows to use scope
-	ClientScopeHandler func(tgr *oauth2.TokenGenerateRequest) (allowed bool, err error)
+    // ClientScopeHandler check the client allows to use scope
+    ClientScopeHandler func(tgr *oauth2.TokenGenerateRequest) (allowed bool, err error)
 
-	// UserAuthorizationHandler get user id from request authorization
-	UserAuthorizationHandler func(w http.ResponseWriter, r *http.Request) (userID string, err error)
+    // UserAuthorizationHandler get user id from request authorization
+    UserAuthorizationHandler func(w http.ResponseWriter, r *http.Request) (userID string, err error)
 
-	// PasswordAuthorizationHandler get user id from username and password
-	PasswordAuthorizationHandler func(ctx context.Context, clientID, username, password string) (userID string, err error)
+    // PasswordAuthorizationHandler get user id from username and password
+    PasswordAuthorizationHandler func(ctx context.Context, clientID, username, password string) (userID string, err error)
 
-	// RefreshingScopeHandler check the scope of the refreshing token
-	RefreshingScopeHandler func(tgr *oauth2.TokenGenerateRequest, oldScope string) (allowed bool, err error)
+    // RefreshingScopeHandler check the scope of the refreshing token
+    RefreshingScopeHandler func(tgr *oauth2.TokenGenerateRequest, oldScope string) (allowed bool, err error)
 
-	// RefreshingValidationHandler check if refresh_token is still valid. eg no revocation or other
-	RefreshingValidationHandler func(ti oauth2.TokenInfo) (allowed bool, err error)
+    // RefreshingValidationHandler check if refresh_token is still valid. eg no revocation or other
+    RefreshingValidationHandler func(ti oauth2.TokenInfo) (allowed bool, err error)
 
-	// ResponseErrorHandler response error handing
-	ResponseErrorHandler func(re *errors.Response)
+    // ResponseErrorHandler response error handing
+    ResponseErrorHandler func(re *errors.Response)
 
-	// InternalErrorHandler internal error handing
-	InternalErrorHandler func(err error) (re *errors.Response)
+    // InternalErrorHandler internal error handing
+    InternalErrorHandler func(err error) (re *errors.Response)
 
-	// PreRedirectErrorHandler is used to override "redirect-on-error" behavior
-	PreRedirectErrorHandler func(w http.ResponseWriter, req *AuthorizeRequest, err error) error
+    // PreRedirectErrorHandler is used to override "redirect-on-error" behavior
+    PreRedirectErrorHandler func(w http.ResponseWriter, req *AuthorizeRequest, err error) error
 
-	// AuthorizeScopeHandler set the authorized scope
-	AuthorizeScopeHandler func(w http.ResponseWriter, r *http.Request) (scope string, err error)
+    // AuthorizeScopeHandler set the authorized scope
+    AuthorizeScopeHandler func(w http.ResponseWriter, r *http.Request) (scope string, err error)
 
-	// AccessTokenExpHandler set expiration date for the access token
-	AccessTokenExpHandler func(w http.ResponseWriter, r *http.Request) (exp time.Duration, err error)
+    // AccessTokenExpHandler set expiration date for the access token
+    AccessTokenExpHandler func(w http.ResponseWriter, r *http.Request) (exp time.Duration, err error)
 
-	// ExtensionFieldsHandler in response to the access token with the extension of the field
-	ExtensionFieldsHandler func(ti oauth2.TokenInfo) (fieldsValue map[string]interface{})
+    // ExtensionFieldsHandler in response to the access token with the extension of the field
+    ExtensionFieldsHandler func(ti oauth2.TokenInfo) (fieldsValue map[string]interface{})
 
-	// ResponseTokenHandler response token handing
-	ResponseTokenHandler func(w http.ResponseWriter, data map[string]interface{}, header http.Header, statusCode ...int) error
+    // ResponseTokenHandler response token handing
+    ResponseTokenHandler func(w http.ResponseWriter, data map[string]interface{}, header http.Header, statusCode ...int) error
 )
 
 // ClientFormHandler get client data from form
 func ClientFormHandler(r *http.Request) (string, string, error) {
-	clientID := r.Form.Get("client_id")
-	if clientID == "" {
-		return "", "", errors.ErrInvalidClient
-	}
-	clientSecret := r.Form.Get("client_secret")
-	return clientID, clientSecret, nil
+    clientID := r.Form.Get("client_id")
+    if clientID == "" {
+        return "", "", errors.ErrInvalidClient
+    }
+    clientSecret := r.Form.Get("client_secret")
+    return clientID, clientSecret, nil
 }
 
 // ClientBasicHandler get client data from basic authorization
 func ClientBasicHandler(r *http.Request) (string, string, error) {
-	username, password, ok := r.BasicAuth()
-	if !ok {
-		return "", "", errors.ErrInvalidClient
-	}
-	return username, password, nil
+    username, password, ok := r.BasicAuth()
+    if !ok {
+        return "", "", errors.ErrInvalidClient
+    }
+
+    usernameUnescaped, err := url.QueryUnescape(username)
+    if err != nil {
+        return "", "", errors.ErrInvalidClient
+    }
+
+    passwordUnescaped, err := url.QueryUnescape(password)
+    if err != nil {
+        return "", "", errors.ErrInvalidClient
+    }
+
+    return usernameUnescaped, passwordUnescaped, nil
 }

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+    "fmt"
+    "net/http"
+    "net/url"
+    "testing"
+)
+
+var clientBasicHandlerTests = []struct {
+    Username         string
+    Password         string
+    ExpectedUsername string
+    ExpectedPassword string
+    ExpectError      bool
+}{
+    {
+        Username:         "username",
+        Password:         "password",
+        ExpectedUsername: "username",
+        ExpectedPassword: "password",
+        ExpectError:      false,
+    },
+    {
+        Username:         url.QueryEscape("+%25%26%2B%C2%A3%E2%82%AC"),
+        Password:         url.QueryEscape("+%25%26%2B%C2%A3%E2%82%AC"),
+        ExpectedUsername: "+%25%26%2B%C2%A3%E2%82%AC",
+        ExpectedPassword: "+%25%26%2B%C2%A3%E2%82%AC",
+        ExpectError:      false,
+    },
+    {
+        Username:         "% +'/€$",
+        Password:         "% +'/€$",
+        ExpectedUsername: "",
+        ExpectedPassword: "",
+        ExpectError:      true,
+    },
+    {
+        Username:         "+%25%26%2B%C2%A3%E2%82%AC",
+        Password:         "+%25%26%2B%C2%A3%E2%82%AC",
+        ExpectedUsername: " %&+£€",
+        ExpectedPassword: " %&+£€",
+        ExpectError:      false,
+    },
+}
+
+func TestClientBasicHandler(t *testing.T) {
+    for i, test := range clientBasicHandlerTests {
+        t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+            req, _ := http.NewRequest("", "", nil)
+            req.SetBasicAuth(test.Username, test.Password)
+
+            username, password, err := ClientBasicHandler(req)
+            if test.ExpectError && err == nil {
+                t.Error("expected error, got nil")
+            } else if !test.ExpectError && err != nil {
+                t.Errorf("unexpected error: %s", err.Error())
+            }
+
+            if test.ExpectedUsername != username {
+                t.Errorf("unexpected username, got %s, want %s", username, test.ExpectedUsername)
+            }
+
+            if test.ExpectedPassword != password {
+                t.Errorf("unexpected password, got %s, want %s", password, test.ExpectedPassword)
+            }
+        })
+    }
+}


### PR DESCRIPTION
Hi,

This PR fix https://github.com/go-oauth2/oauth2/issues/235. It may break clients that do not encode the username and password when using basic authentication.
