### PR TITLE
Remove .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,0 @@
-[*.go]
-end_of_line = crlf


### PR DESCRIPTION
The .editorconfig only contains a single setting,
overriding line endings for go files to CRLF.

The go files in the repo are checked in with the
go fmt defaults of LF endings though.

On editors that respect .editorconfig, the misconfiguration implies that on every save all line endings get converted to CRLF which is undesired, given the state of the repo.