### PR TITLE
Refresh and Access token resolve handler

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -51,6 +51,9 @@ type (
 
 	// ResponseTokenHandler response token handling
 	ResponseTokenHandler func(w http.ResponseWriter, data map[string]interface{}, header http.Header, statusCode ...int) error
+
+	// Handler to fetch the refresh token from the request
+	RefreshTokenResolveHandler func(r *http.Request) (string, error)
 )
 
 // ClientFormHandler get client data from form
@@ -70,4 +73,22 @@ func ClientBasicHandler(r *http.Request) (string, string, error) {
 		return "", "", errors.ErrInvalidClient
 	}
 	return username, password, nil
+}
+
+func RefreshTokenFormResolveHandler(r *http.Request) (string, error) {
+	rt := r.FormValue("refresh_token")
+	if rt == "" {
+		return "", errors.ErrInvalidRequest
+	}
+
+	return rt, nil
+}
+
+func RefreshTokenCookieResolveHandler(r *http.Request) (string, error) {
+	c, err := r.Cookie("refresh_token")
+	if err != nil {
+		return "", errors.ErrInvalidRequest
+	}
+
+	return c.Value, nil
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -49,7 +49,7 @@ type (
 	// ExtensionFieldsHandler in response to the access token with the extension of the field
 	ExtensionFieldsHandler func(ti oauth2.TokenInfo) (fieldsValue map[string]interface{})
 
-	// ResponseTokenHandler response token handing
+	// ResponseTokenHandler response token handling
 	ResponseTokenHandler func(w http.ResponseWriter, data map[string]interface{}, header http.Header, statusCode ...int) error
 )
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-oauth2/oauth2/v4"
@@ -54,6 +55,9 @@ type (
 
 	// Handler to fetch the refresh token from the request
 	RefreshTokenResolveHandler func(r *http.Request) (string, error)
+
+	// Handler to fetch the access token from the request
+	AccessTokenResolveHandler func(r *http.Request) (string, bool)
 )
 
 // ClientFormHandler get client data from form
@@ -91,4 +95,27 @@ func RefreshTokenCookieResolveHandler(r *http.Request) (string, error) {
 	}
 
 	return c.Value, nil
+}
+
+func AccessTokenDefaultResolveHandler(r *http.Request) (string, bool) {
+	token := ""
+	auth := r.Header.Get("Authorization")
+	prefix := "Bearer "
+
+	if auth != "" && strings.HasPrefix(auth, prefix) {
+		token = auth[len(prefix):]
+	} else {
+		token = r.FormValue("access_token")
+	}
+
+	return token, token != ""
+}
+
+func AccessTokenCookieResolveHandler(r *http.Request) (string, bool) {
+	c, err := r.Cookie("access_token")
+	if err != nil {
+		return "", false
+	}
+
+	return c.Value, true
 }

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-oauth2/oauth2/v4/errors"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRefreshTokenFormResolveHandler(t *testing.T) {
+	Convey("Correct Request", t, func() {
+		f := url.Values{}
+		f.Add("refresh_token", "test_token")
+
+		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(f.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		token, err := RefreshTokenFormResolveHandler(r)
+		So(err, ShouldBeNil)
+		So(token, ShouldEqual, "test_token")
+	})
+
+	Convey("Missing Refresh Token", t, func() {
+		r := httptest.NewRequest("POST", "/", nil)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		token, err := RefreshTokenFormResolveHandler(r)
+		So(err, ShouldBeError, errors.ErrInvalidRequest)
+		So(token, ShouldBeEmpty)
+	})
+}
+
+func TestRefreshTokenCookieResolveHandler(t *testing.T) {
+	Convey("Correct Request", t, func() {
+		r := httptest.NewRequest(http.MethodPost, "/", nil)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.AddCookie(&http.Cookie{
+			Name:     "refresh_token",
+			Value:    "test_token",
+			HttpOnly: true,
+			Path:     "/",
+			Domain:   ".example.com",
+			Expires:  time.Now().Add(time.Hour),
+		})
+
+		token, err := RefreshTokenCookieResolveHandler(r)
+		So(err, ShouldBeNil)
+		So(token, ShouldEqual, "test_token")
+	})
+
+	Convey("Missing Refresh Token", t, func() {
+		r := httptest.NewRequest("POST", "/", nil)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		token, err := RefreshTokenCookieResolveHandler(r)
+		So(err, ShouldBeError, errors.ErrInvalidRequest)
+		So(token, ShouldBeEmpty)
+	})
+}

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -93,3 +93,13 @@ func (s *Server) SetAuthorizeScopeHandler(handler AuthorizeScopeHandler) {
 func (s *Server) SetResponseTokenHandler(handler ResponseTokenHandler) {
 	s.ResponseTokenHandler = handler
 }
+
+// SetRefreshTokenResolveHandler refresh token resolver
+func (s *Server) SetRefreshTokenResolveHandler(handler RefreshTokenResolveHandler) {
+	s.RefreshTokenResolveHandler = handler
+}
+
+// SetAccessTokenResolveHandler access token resolver
+func (s *Server) SetAccessTokenResolveHandler(handler AccessTokenResolveHandler) {
+	s.AccessTokenResolveHandler = handler
+}


### PR DESCRIPTION
So we use this library but now we want to store the tokens in HttpOnly cookies. Like this when we want to get a new access token with the refresh token we have to get the refresh token from the cookie and our client can't include it in the request body.

The default functionality is the same as before and I have included a new handler for the cookie too. I have included some unit tests too.