### PR TITLE
fix: change error type from ErrUnauthorizedClient to ErrUnsupportedGrantType for unsupported grant types

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -393,7 +393,7 @@ func (s *Server) CheckGrantType(gt oauth2.GrantType) bool {
 func (s *Server) GetAccessToken(ctx context.Context, gt oauth2.GrantType, tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo,
 	error) {
 	if allowed := s.CheckGrantType(gt); !allowed {
-		return nil, errors.ErrUnauthorizedClient
+		return nil, errors.ErrUnsupportedGrantType
 	}
 
 	if fn := s.ClientAuthorizedHandler; fn != nil {


### PR DESCRIPTION
## Summary

This PR fixes an incorrect error type returned when an unsupported grant type is encountered in the OAuth2 server.

## Changes

- Changed error type from `ErrUnauthorizedClient` to `ErrUnsupportedGrantType` in `GetAccessToken` function
- Improves error message accuracy for OAuth2 grant type validation scenarios

## Files Modified

- `server/server.go`: Updated error return value in line 396

## Why This Change?

The previous error type `ErrUnauthorizedClient` was semantically incorrect for cases where the grant type itself is not supported. According to OAuth2 specifications, `unsupported_grant_type` is the appropriate error code for this scenario.

## Testing

- [x] Existing tests pass
- [x] Error handling behavior verified

## Impact

- Better error reporting for API consumers
- Improved compliance with OAuth2 error handling standards
- No breaking changes to existing functionality