### PR TITLE
feat(manage): add SetGrantTypeTokenCfg for custom grant type support

### DIFF
--- a/manage/manager.go
+++ b/manage/manager.go
@@ -85,6 +85,12 @@ func (m *Manager) SetClientTokenCfg(cfg *Config) {
 	m.gtcfg[oauth2.ClientCredentials] = cfg
 }
 
+// SetGrantTypeTokenCfg set the token config for a specific grant type
+// This method allows configuring custom grant types beyond the standard OAuth2 grant types
+func (m *Manager) SetGrantTypeTokenCfg(gt oauth2.GrantType, cfg *Config) {
+	m.gtcfg[gt] = cfg
+}
+
 // SetRefreshTokenCfg set the refreshing token config
 func (m *Manager) SetRefreshTokenCfg(cfg *RefreshingConfig) {
 	m.rcfg = cfg


### PR DESCRIPTION
## Summary
 
- Add `SetGrantTypeTokenCfg(gt oauth2.GrantType, cfg *Config)` method to `Manager` struct to enable custom grant type configuration
 
## Problem
 
The `Manager` struct has a private `gtcfg` field (`map[oauth2.GrantType]*Config`), but only provides configuration methods for the 4 standard OAuth2 grant types:
- `SetAuthorizeCodeTokenCfg`
- `SetImplicitTokenCfg`
- `SetPasswordTokenCfg`
- `SetClientTokenCfg`
 
This design prevents users from configuring custom grant types, which is a common requirement in OAuth2 implementations (e.g., `device_code`, `urn:ietf:params:oauth:grant-type:jwt-bearer`, etc.).
 
## Solution
 
Add a generic `SetGrantTypeTokenCfg(gt oauth2.GrantType, cfg *Config)` method that allows users to configure token settings for any grant type, including custom ones.
 
## Usage Example
 
```go
// Define a custom grant type
const DeviceCodeGrant oauth2.GrantType = "urn:ietf:params:oauth:grant-type:device_code"
 
// Configure the custom grant type
manager.SetGrantTypeTokenCfg(DeviceCodeGrant, &manage.Config{
    AccessTokenExp:    time.Hour * 2,
    RefreshTokenExp:   time.Hour * 24 * 7,
    IsGenerateRefresh: true,
})