### PR TITLE
 Adds ID-JAG JWT Bearer grant support (draft-ietf-oauth-identity-assertion-authz-grant-03)

### DIFF
--- a/const.go
+++ b/const.go
@@ -29,13 +29,14 @@ const (
 	ClientCredentials   GrantType = "client_credentials"
 	Refreshing          GrantType = "refresh_token"
 	Implicit            GrantType = "__implicit"
+	JWTBearer           GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 )
 
 func (gt GrantType) String() string {
 	if gt == AuthorizationCode ||
 		gt == PasswordCredentials ||
 		gt == ClientCredentials ||
-		gt == Refreshing {
+		gt == Refreshing || gt == JWTBearer {
 		return string(gt)
 	}
 	return ""

--- a/const.go
+++ b/const.go
@@ -36,7 +36,8 @@ func (gt GrantType) String() string {
 	if gt == AuthorizationCode ||
 		gt == PasswordCredentials ||
 		gt == ClientCredentials ||
-		gt == Refreshing || gt == JWTBearer {
+		gt == Refreshing ||
+		gt == JWTBearer {
 		return string(gt)
 	}
 	return ""

--- a/errors/error.go
+++ b/errors/error.go
@@ -7,13 +7,14 @@ var New = errors.New
 
 // known errors
 var (
-	ErrInvalidRedirectURI   = errors.New("invalid redirect uri")
-	ErrInvalidAuthorizeCode = errors.New("invalid authorize code")
-	ErrInvalidAccessToken   = errors.New("invalid access token")
-	ErrInvalidRefreshToken  = errors.New("invalid refresh token")
-	ErrExpiredAccessToken   = errors.New("expired access token")
-	ErrExpiredRefreshToken  = errors.New("expired refresh token")
-	ErrMissingCodeVerifier  = errors.New("missing code verifier")
-	ErrMissingCodeChallenge = errors.New("missing code challenge")
-	ErrInvalidCodeChallenge = errors.New("invalid code challenge")
+	ErrInvalidRedirectURI             = errors.New("invalid redirect uri")
+	ErrInvalidAuthorizeCode           = errors.New("invalid authorize code")
+	ErrInvalidAccessToken             = errors.New("invalid access token")
+	ErrInvalidRefreshToken            = errors.New("invalid refresh token")
+	ErrExpiredAccessToken             = errors.New("expired access token")
+	ErrExpiredRefreshToken            = errors.New("expired refresh token")
+	ErrMissingCodeVerifier            = errors.New("missing code verifier")
+	ErrMissingCodeChallenge           = errors.New("missing code challenge")
+	ErrInvalidCodeChallenge           = errors.New("invalid code challenge")
+	ErrInsufficientUserAuthentication = errors.New("insufficient_user_authentication")
 )

--- a/errors/response.go
+++ b/errors/response.go
@@ -64,6 +64,7 @@ var Descriptions = map[error]string{
 	ErrCodeChallengeRquired:           "PKCE is required. code_challenge is missing",
 	ErrUnsupportedCodeChallengeMethod: "Selected code_challenge_method not supported",
 	ErrInvalidCodeChallengeLen:        "Code challenge length must be between 43 and 128 charachters long",
+	ErrInsufficientUserAuthentication: "The authentication event does not meet the required assurance level",
 }
 
 // StatusCodes response error HTTP status code
@@ -81,4 +82,5 @@ var StatusCodes = map[error]int{
 	ErrCodeChallengeRquired:           400,
 	ErrUnsupportedCodeChallengeMethod: 400,
 	ErrInvalidCodeChallengeLen:        400,
+	ErrInsufficientUserAuthentication: 400,
 }

--- a/manage.go
+++ b/manage.go
@@ -20,6 +20,7 @@ type TokenGenerateRequest struct {
 	CodeVerifier        string
 	AccessTokenExp      time.Duration
 	Request             *http.Request
+	Assertion           string
 }
 
 // Manager authorization management interface

--- a/manage/config.go
+++ b/manage/config.go
@@ -36,4 +36,5 @@ var (
 	DefaultPasswordTokenCfg      = &Config{AccessTokenExp: time.Hour * 2, RefreshTokenExp: time.Hour * 24 * 7, IsGenerateRefresh: true}
 	DefaultClientTokenCfg        = &Config{AccessTokenExp: time.Hour * 2}
 	DefaultRefreshTokenCfg       = &RefreshingConfig{IsGenerateRefresh: true, IsRemoveAccess: true, IsRemoveRefreshing: true}
+	DefaultJWTBearerTokenCfg     = &Config{AccessTokenExp: time.Hour * 2, IsGenerateRefresh: false}
 )

--- a/manage/manager.go
+++ b/manage/manager.go
@@ -56,6 +56,8 @@ func (m *Manager) grantConfig(gt oauth2.GrantType) *Config {
 		return DefaultPasswordTokenCfg
 	case oauth2.ClientCredentials:
 		return DefaultClientTokenCfg
+	case oauth2.JWTBearer:
+		return DefaultJWTBearerTokenCfg
 	}
 	return &Config{}
 }
@@ -516,4 +518,8 @@ func (m *Manager) LoadRefreshToken(ctx context.Context, refresh string) (oauth2.
 		return nil, errors.ErrExpiredRefreshToken
 	}
 	return ti, nil
+}
+
+func (m *Manager) SetGrantTypeCfg(gt oauth2.GrantType, cfg *Config) {
+	m.gtcfg[gt] = cfg
 }

--- a/server/config.go
+++ b/server/config.go
@@ -15,6 +15,13 @@ type Config struct {
 	AllowedGrantTypes           []oauth2.GrantType    // allow the grant type
 	AllowedCodeChallengeMethods []oauth2.CodeChallengeMethod
 	ForcePKCE                   bool
+	TrustedIDJAGIssuers         []string                  // iss allowlist
+	IDJAGAudience               string                    // expected aud (RFC 8414 issuer identifier)
+	IDJAGClockSkew              time.Duration             // default 60s applied at runtime
+	IDJAGAllowPublicClients     bool                      // default false
+	IDJAGIssuerKeyResolver      IssuerKeyResolver         // required when JWTBearer enabled
+	IDJAGAuthorizationHandler   IDJAGAuthorizationHandler // policy hook
+	IDJAGReplayStore            oauth2.AssertionReplayStore
 }
 
 // NewConfig create to configuration instance

--- a/server/idjag.go
+++ b/server/idjag.go
@@ -1,0 +1,296 @@
+package server
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-oauth2/oauth2/v4/errors"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type IssuerKeyResolver func(ctx context.Context, issuer, kid string) ([]crypto.PublicKey, error)
+type IDJAGAuthorizationHandler func(ctx context.Context, claims IDJAGClaims, req IDJAGRequest) (IDJAGGrant, error)
+
+var allowedIDJAGAlgorithms = []string{
+	"RS256", "ES256", "PS256",
+}
+
+const IDJAGType = "oauth-id-jag+jwt"
+
+type IDJAGClaims struct {
+	Issuer, Subject, ClientID, JTI string
+	ExpiresAt, IssuedAt            time.Time
+	Scope                          string
+	Resource                       []string
+	AuthorizationDetails           []map[string]any
+}
+
+type IDJAGRequest struct {
+	Scope                string
+	Resource             []string
+	AuthorizationDetails []map[string]any
+}
+
+type IDJAGGrant struct {
+	Scope                string
+	Resource             []string
+	AuthorizationDetails []map[string]any
+}
+
+type idjagRawClaims struct {
+	jwt.RegisteredClaims
+	ClientID             string           `json:"client_id"`
+	Scope                string           `json:"scope,omitempty"`
+	Resource             []string         `json:"resource,omitempty"`
+	AuthorizationDetails []map[string]any `json:"authorization_details,omitempty"`
+	// Tolerated optional claims (spec §3.1): Tenant, AuthTime, ACR, AMR, AudTenant, AudSub, Email, Act
+}
+
+func validateIDJAGAssertion(ctx context.Context, cfg *Config, clientID, assertion string) (*IDJAGClaims, error) {
+	unverified, _, err := jwt.NewParser().ParseUnverified(assertion, &idjagRawClaims{})
+	if err != nil {
+		return nil, errors.ErrInvalidRequest
+	}
+	typ, _ := unverified.Header["typ"].(string)
+	if typ != IDJAGType {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	alg, _ := unverified.Header["alg"].(string)
+	algAllowed := false
+	for _, a := range allowedIDJAGAlgorithms {
+		if alg == a {
+			algAllowed = true
+			break
+		}
+	}
+	if !algAllowed {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	unverifiedClaims := unverified.Claims.(*idjagRawClaims)
+	iss := unverifiedClaims.Issuer
+	kid, _ := unverified.Header["kid"].(string)
+	issuerTrusted := false
+	for _, trusted := range cfg.TrustedIDJAGIssuers {
+		if iss == trusted {
+			issuerTrusted = true
+			break
+		}
+	}
+	if !issuerTrusted {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	keys, err := cfg.IDJAGIssuerKeyResolver(ctx, iss, kid)
+	if err != nil || len(keys) == 0 {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	clockSkew := cfg.IDJAGClockSkew
+	if clockSkew == 0 {
+		clockSkew = 60 * time.Second
+	}
+
+	var verified *idjagRawClaims
+	for _, key := range keys {
+		k := key
+		var c idjagRawClaims
+		_, parseErr := jwt.NewParser(
+			jwt.WithValidMethods(allowedIDJAGAlgorithms),
+			jwt.WithLeeway(clockSkew),
+			jwt.WithExpirationRequired(),
+		).ParseWithClaims(assertion, &c, func(_ *jwt.Token) (interface{}, error) {
+			return k, nil
+		})
+		if parseErr == nil {
+			verified = &c
+			break
+		}
+	}
+	if verified == nil {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	if verified.Issuer == "" || verified.Subject == "" || verified.ID == "" || verified.ClientID == "" {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	if verified.ExpiresAt == nil || verified.IssuedAt == nil {
+		return nil, errors.ErrInvalidGrant
+	}
+	if verified.IssuedAt.Time.After(time.Now().Add(clockSkew)) {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	audFound := false
+	for _, a := range verified.Audience {
+		if a == cfg.IDJAGAudience {
+			audFound = true
+			break
+		}
+	}
+
+	if !audFound {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	if verified.ClientID != clientID {
+		return nil, errors.ErrInvalidGrant
+	}
+
+	if cfg.IDJAGReplayStore != nil {
+		if err := cfg.IDJAGReplayStore.StoreAssertionID(ctx, verified.ID, verified.ExpiresAt.Time); err != nil {
+			return nil, errors.ErrInvalidGrant
+		}
+	}
+
+	return &IDJAGClaims{
+		Issuer:               verified.Issuer,
+		Subject:              verified.Subject,
+		ClientID:             verified.ClientID,
+		JTI:                  verified.ID,
+		ExpiresAt:            verified.ExpiresAt.Time,
+		IssuedAt:             verified.IssuedAt.Time,
+		Scope:                verified.Scope,
+		Resource:             verified.Resource,
+		AuthorizationDetails: verified.AuthorizationDetails,
+	}, nil
+}
+
+func NewOIDCIssuerKeyResolver(httpClient *http.Client) IssuerKeyResolver {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return func(ctx context.Context, issuer, kid string) ([]crypto.PublicKey, error) {
+		configURL := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, configURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		var oidcConfig struct {
+			JWKSURI string `json:"jwks_uri"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&oidcConfig); err != nil {
+			return nil, err
+		}
+		if oidcConfig.JWKSURI == "" {
+			return nil, fmt.Errorf("missing jwks_uri in openid-configuration")
+		}
+
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, oidcConfig.JWKSURI, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		var jwks struct {
+			Keys []json.RawMessage `json:"keys"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+			return nil, err
+		}
+
+		var keys []crypto.PublicKey
+		for _, rawKey := range jwks.Keys {
+			var meta struct {
+				Kty string `json:"kty"`
+				Kid string `json:"kid"`
+			}
+			if err := json.Unmarshal(rawKey, &meta); err != nil {
+				continue
+			}
+			if kid != "" && meta.Kid != kid {
+				continue
+			}
+			switch meta.Kty {
+			case "RSA":
+				if k, err := parseRSAPublicKey(rawKey); err == nil {
+					keys = append(keys, k)
+				}
+			case "EC":
+				if k, err := parseECPublicKey(rawKey); err == nil {
+					keys = append(keys, k)
+				}
+			}
+		}
+		return keys, nil
+	}
+}
+
+func parseRSAPublicKey(raw json.RawMessage) (*rsa.PublicKey, error) {
+	var k struct {
+		N string `json:"n"`
+		E string `json:"e"`
+	}
+	if err := json.Unmarshal(raw, &k); err != nil {
+		return nil, err
+	}
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, err
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: int(new(big.Int).SetBytes(eBytes).Int64()),
+	}, nil
+}
+
+func parseECPublicKey(raw json.RawMessage) (*ecdsa.PublicKey, error) {
+	var k struct {
+		Crv string `json:"crv"`
+		X   string `json:"x"`
+		Y   string `json:"y"`
+	}
+	if err := json.Unmarshal(raw, &k); err != nil {
+		return nil, err
+	}
+	xBytes, err := base64.RawURLEncoding.DecodeString(k.X)
+	if err != nil {
+		return nil, err
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(k.Y)
+	if err != nil {
+		return nil, err
+	}
+	var curve elliptic.Curve
+	switch k.Crv {
+	case "P-256":
+		curve = elliptic.P256()
+	case "P-384":
+		curve = elliptic.P384()
+	case "P-521":
+		curve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("unsupported EC curve: %s", k.Crv)
+	}
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     new(big.Int).SetBytes(xBytes),
+		Y:     new(big.Int).SetBytes(yBytes),
+	}, nil
+}

--- a/server/idjag.go
+++ b/server/idjag.go
@@ -183,6 +183,10 @@ func NewOIDCIssuerKeyResolver(httpClient *http.Client) IssuerKeyResolver {
 			return nil, err
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("fetching openid-configuration: unexpected status %d", resp.StatusCode)
+		}
 
 		var oidcConfig struct {
 			JWKSURI string `json:"jwks_uri"`
@@ -203,6 +207,10 @@ func NewOIDCIssuerKeyResolver(httpClient *http.Client) IssuerKeyResolver {
 			return nil, err
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("fetching jwks: unexpected status %d", resp.StatusCode)
+		}
 
 		var jwks struct {
 			Keys []json.RawMessage `json:"keys"`
@@ -288,9 +296,9 @@ func parseECPublicKey(raw json.RawMessage) (*ecdsa.PublicKey, error) {
 	default:
 		return nil, fmt.Errorf("unsupported EC curve: %s", k.Crv)
 	}
-	return &ecdsa.PublicKey{
-		Curve: curve,
-		X:     new(big.Int).SetBytes(xBytes),
-		Y:     new(big.Int).SetBytes(yBytes),
-	}, nil
+	x, y := new(big.Int).SetBytes(xBytes), new(big.Int).SetBytes(yBytes)
+	if !curve.IsOnCurve(x, y) {
+		return nil, fmt.Errorf("EC point is not on curve %s", k.Crv)
+	}
+	return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}, nil
 }

--- a/server/idjag_test.go
+++ b/server/idjag_test.go
@@ -1,0 +1,345 @@
+package server
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	oauth2pkg "github.com/go-oauth2/oauth2/v4"
+	"github.com/go-oauth2/oauth2/v4/errors"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	testIssuer   = "https://idp.example.com"
+	testAudience = "https://as.example.com"
+	testClientID = "client-abc"
+	testSubject  = "user@example.com"
+)
+
+func mustGenRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+func staticKeyResolver(pub crypto.PublicKey) IssuerKeyResolver {
+	return func(_ context.Context, _, _ string) ([]crypto.PublicKey, error) {
+		return []crypto.PublicKey{pub}, nil
+	}
+}
+
+func baseConfig(key *rsa.PrivateKey) *Config {
+	return &Config{
+		TrustedIDJAGIssuers:    []string{testIssuer},
+		IDJAGAudience:          testAudience,
+		IDJAGIssuerKeyResolver: staticKeyResolver(&key.PublicKey),
+	}
+}
+
+func signRS256(t *testing.T, key *rsa.PrivateKey, claims jwt.MapClaims, headerOverrides map[string]any) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["typ"] = IDJAGType
+	for k, v := range headerOverrides {
+		tok.Header[k] = v
+	}
+	s, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// noneAlgToken crafts a JWT with alg:none (no valid signature).
+func noneAlgToken(claims map[string]any) string {
+	h, _ := json.Marshal(map[string]any{"alg": "none", "typ": IDJAGType})
+	c, _ := json.Marshal(claims)
+	return base64.RawURLEncoding.EncodeToString(h) + "." +
+		base64.RawURLEncoding.EncodeToString(c) + "."
+}
+
+func validClaims(jti string, expOffset time.Duration) jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":       testIssuer,
+		"sub":       testSubject,
+		"aud":       []string{testAudience},
+		"client_id": testClientID,
+		"jti":       jti,
+		"exp":       now.Add(expOffset).Unix(),
+		"iat":       now.Unix(),
+	}
+}
+
+func TestValidateIDJAGAssertion(t *testing.T) {
+	key := mustGenRSAKey(t)
+	cfg := baseConfig(key)
+
+	tests := []struct {
+		name      string
+		assertion func() string
+		clientID  string
+		cfg       *Config
+		wantErr   error
+	}{
+		{
+			name:      "valid RS256 assertion",
+			assertion: func() string { return signRS256(t, key, validClaims("jti-ok", 5*time.Minute), nil) },
+			clientID:  testClientID,
+			cfg:       cfg,
+		},
+		{
+			name: "typ JWT rejected",
+			assertion: func() string {
+				return signRS256(t, key, validClaims("jti-typ-jwt", 5*time.Minute), map[string]any{"typ": "JWT"})
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			name: "typ id_token rejected",
+			assertion: func() string {
+				return signRS256(t, key, validClaims("jti-typ-idtoken", 5*time.Minute), map[string]any{"typ": "id_token"})
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			name: "alg none rejected",
+			assertion: func() string {
+				now := time.Now()
+				return noneAlgToken(map[string]any{
+					"iss": testIssuer, "sub": testSubject, "aud": []string{testAudience},
+					"client_id": testClientID, "jti": "jti-none",
+					"exp": now.Add(5 * time.Minute).Unix(), "iat": now.Unix(),
+				})
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			name: "alg HS256 rejected",
+			assertion: func() string {
+				tok := jwt.NewWithClaims(jwt.SigningMethodHS256, validClaims("jti-hs256", 5*time.Minute))
+				tok.Header["typ"] = IDJAGType
+				s, err := tok.SignedString([]byte("secret"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return s
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			name: "untrusted issuer rejected",
+			assertion: func() string {
+				c := validClaims("jti-bad-iss", 5*time.Minute)
+				c["iss"] = "https://evil.example.com"
+				return signRS256(t, key, c, nil)
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			name: "wrong aud rejected",
+			assertion: func() string {
+				c := validClaims("jti-bad-aud", 5*time.Minute)
+				c["aud"] = []string{"https://wrong.example.com"}
+				return signRS256(t, key, c, nil)
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			name:      "client_id mismatch rejected",
+			assertion: func() string { return signRS256(t, key, validClaims("jti-cid-mismatch", 5*time.Minute), nil) },
+			clientID:  "other-client",
+			cfg:       cfg,
+			wantErr:   errors.ErrInvalidGrant,
+		},
+		{
+			name:      "expired outside clock skew rejected",
+			assertion: func() string { return signRS256(t, key, validClaims("jti-expired", -90*time.Second), nil) },
+			clientID:  testClientID,
+			cfg:       cfg,
+			wantErr:   errors.ErrInvalidGrant,
+		},
+		{
+			// Token expired 30s ago; default clock skew is 60s — should succeed.
+			name:      "expired within clock skew accepted",
+			assertion: func() string { return signRS256(t, key, validClaims("jti-skew", -30*time.Second), nil) },
+			clientID:  testClientID,
+			cfg:       cfg,
+		},
+		{
+			name: "missing jti rejected",
+			assertion: func() string {
+				c := validClaims("", 5*time.Minute)
+				delete(c, "jti")
+				return signRS256(t, key, c, nil)
+			},
+			clientID: testClientID,
+			cfg:      cfg,
+			wantErr:  errors.ErrInvalidGrant,
+		},
+		{
+			// Store is pre-populated with the same jti before validation runs.
+			name:      "replay rejected",
+			assertion: func() string { return signRS256(t, key, validClaims("jti-replay", 5*time.Minute), nil) },
+			clientID:  testClientID,
+			cfg: func() *Config {
+				c := *cfg
+				c.IDJAGReplayStore = oauth2pkg.NewMemoryAssertionReplayStore()
+				_ = c.IDJAGReplayStore.StoreAssertionID(context.Background(), "jti-replay", time.Now().Add(5*time.Minute))
+				return &c
+			}(),
+			wantErr: errors.ErrInvalidGrant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateIDJAGAssertion(context.Background(), tt.cfg, tt.clientID, tt.assertion())
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Errorf("got %v, want %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateIDJAGAssertionReturnedClaims(t *testing.T) {
+	key := mustGenRSAKey(t)
+	cfg := baseConfig(key)
+
+	claims := validClaims("jti-claims-check", 5*time.Minute)
+	claims["scope"] = "read write"
+	claims["resource"] = []string{"https://api.example.com"}
+
+	got, err := validateIDJAGAssertion(context.Background(), cfg, testClientID, signRS256(t, key, claims, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Issuer != testIssuer {
+		t.Errorf("Issuer: got %q want %q", got.Issuer, testIssuer)
+	}
+	if got.Subject != testSubject {
+		t.Errorf("Subject: got %q want %q", got.Subject, testSubject)
+	}
+	if got.ClientID != testClientID {
+		t.Errorf("ClientID: got %q want %q", got.ClientID, testClientID)
+	}
+	if got.JTI != "jti-claims-check" {
+		t.Errorf("JTI: got %q want %q", got.JTI, "jti-claims-check")
+	}
+	if got.Scope != "read write" {
+		t.Errorf("Scope: got %q want %q", got.Scope, "read write")
+	}
+	if len(got.Resource) != 1 || got.Resource[0] != "https://api.example.com" {
+		t.Errorf("Resource: got %v", got.Resource)
+	}
+}
+
+func TestNewOIDCIssuerKeyResolver(t *testing.T) {
+	key := mustGenRSAKey(t)
+	kid := "key-1"
+
+	n := base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(new(big.Int).SetInt64(int64(key.PublicKey.E)).Bytes())
+
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			json.NewEncoder(w).Encode(map[string]string{"jwks_uri": ts.URL + "/jwks"})
+		case "/jwks":
+			json.NewEncoder(w).Encode(map[string]any{
+				"keys": []map[string]any{
+					{"kty": "RSA", "kid": kid, "n": n, "e": e},
+				},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	resolver := NewOIDCIssuerKeyResolver(nil)
+
+	t.Run("matching kid returns key", func(t *testing.T) {
+		keys, err := resolver(context.Background(), ts.URL, kid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(keys))
+		}
+		rsaKey, ok := keys[0].(*rsa.PublicKey)
+		if !ok {
+			t.Fatal("expected *rsa.PublicKey")
+		}
+		if rsaKey.N.Cmp(key.PublicKey.N) != 0 {
+			t.Error("key modulus mismatch")
+		}
+	})
+
+	t.Run("empty kid returns all keys", func(t *testing.T) {
+		keys, err := resolver(context.Background(), ts.URL, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(keys))
+		}
+	})
+
+	t.Run("non-matching kid returns empty slice", func(t *testing.T) {
+		keys, err := resolver(context.Background(), ts.URL, "other-kid")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("expected 0 keys, got %d", len(keys))
+		}
+	})
+
+	t.Run("missing jwks_uri returns error", func(t *testing.T) {
+		badTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]string{})
+		}))
+		defer badTs.Close()
+		_, err := resolver(context.Background(), badTs.URL, "")
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("cancelled context returns error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := resolver(ctx, ts.URL, kid)
+		if err == nil {
+			t.Error("expected error from cancelled context, got nil")
+		}
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/go-oauth2/oauth2/v4"
 	"github.com/go-oauth2/oauth2/v4/errors"
 )
+
+var warnPublicClientsOnce sync.Once
 
 // NewDefaultServer create a default authorization server
 func NewDefaultServer(manager oauth2.Manager) *Server {
@@ -375,6 +379,11 @@ func (s *Server) ValidationTokenRequest(r *http.Request) (oauth2.GrantType, *oau
 		if err != nil {
 			return "", nil, err
 		}
+	case oauth2.JWTBearer:
+		if r.FormValue("assertion") == "" {
+			return "", nil, errors.ErrInvalidRequest
+		}
+		tgr.Scope = r.FormValue("scope")
 	}
 	return gt, tgr, nil
 }
@@ -393,7 +402,7 @@ func (s *Server) CheckGrantType(gt oauth2.GrantType) bool {
 func (s *Server) GetAccessToken(ctx context.Context, gt oauth2.GrantType, tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo,
 	error) {
 	if allowed := s.CheckGrantType(gt); !allowed {
-		return nil, errors.ErrUnauthorizedClient
+		return nil, errors.ErrUnsupportedGrantType
 	}
 
 	if fn := s.ClientAuthorizedHandler; fn != nil {
@@ -472,9 +481,66 @@ func (s *Server) GetAccessToken(ctx context.Context, gt oauth2.GrantType, tgr *o
 			return nil, err
 		}
 		return ti, nil
+	case oauth2.JWTBearer:
+		return s.handleIDJAGGrant(ctx, tgr)
 	}
 
 	return nil, errors.ErrUnsupportedGrantType
+}
+
+func (s *Server) handleIDJAGGrant(ctx context.Context, tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo, error) {
+	cfg := s.Config
+	if cfg.IDJAGIssuerKeyResolver == nil || len(cfg.TrustedIDJAGIssuers) == 0 || cfg.IDJAGAudience == "" {
+		return nil, errors.ErrServerError
+	}
+
+	cli, err := s.Manager.GetClient(ctx, tgr.ClientID)
+	if err != nil {
+		return nil, errors.ErrInvalidClient
+	}
+	if cli.IsPublic() && !cfg.IDJAGAllowPublicClients {
+		return nil, errors.ErrUnauthorizedClient
+	}
+	if cfg.IDJAGAllowPublicClients {
+		warnPublicClientsOnce.Do(func() {
+			log.Println("[WARNING] IDJAGAllowPublicClients is enabled — public clients may use the JWT Bearer grant; do not use in production")
+		})
+	}
+
+	assertion := tgr.Request.FormValue("assertion")
+	claims, err := validateIDJAGAssertion(ctx, cfg, tgr.ClientID, assertion)
+	if err != nil {
+		return nil, err
+	}
+
+	grant := IDJAGGrant{
+		Scope:                claims.Scope,
+		Resource:             claims.Resource,
+		AuthorizationDetails: claims.AuthorizationDetails,
+	}
+	// Request scope takes priority over assertion scope (RFC 6749 §3.3).
+	if tgr.Scope != "" {
+		grant.Scope = tgr.Scope
+	}
+
+	if cfg.IDJAGAuthorizationHandler != nil {
+		req := IDJAGRequest{
+			Scope:                grant.Scope,
+			Resource:             claims.Resource,
+			AuthorizationDetails: claims.AuthorizationDetails,
+		}
+		grant, err = cfg.IDJAGAuthorizationHandler(ctx, *claims, req)
+		if err != nil {
+			return nil, err
+		}
+		if grant.Scope == "" && len(grant.Resource) == 0 && len(grant.AuthorizationDetails) == 0 {
+			return nil, errors.ErrInvalidScope
+		}
+	}
+
+	tgr.UserID = claims.Subject
+	tgr.Scope = grant.Scope
+	return s.Manager.GenerateAccessToken(ctx, oauth2.JWTBearer, tgr)
 }
 
 // GetTokenData token data

--- a/server/server.go
+++ b/server/server.go
@@ -380,7 +380,8 @@ func (s *Server) ValidationTokenRequest(r *http.Request) (oauth2.GrantType, *oau
 			return "", nil, err
 		}
 	case oauth2.JWTBearer:
-		if r.FormValue("assertion") == "" {
+		tgr.Assertion = r.FormValue("assertion")
+		if tgr.Assertion == "" {
 			return "", nil, errors.ErrInvalidRequest
 		}
 		tgr.Scope = r.FormValue("scope")
@@ -402,7 +403,7 @@ func (s *Server) CheckGrantType(gt oauth2.GrantType) bool {
 func (s *Server) GetAccessToken(ctx context.Context, gt oauth2.GrantType, tgr *oauth2.TokenGenerateRequest) (oauth2.TokenInfo,
 	error) {
 	if allowed := s.CheckGrantType(gt); !allowed {
-		return nil, errors.ErrUnsupportedGrantType
+		return nil, errors.ErrUnauthorizedClient
 	}
 
 	if fn := s.ClientAuthorizedHandler; fn != nil {
@@ -507,7 +508,7 @@ func (s *Server) handleIDJAGGrant(ctx context.Context, tgr *oauth2.TokenGenerate
 		})
 	}
 
-	assertion := tgr.Request.FormValue("assertion")
+	assertion := tgr.Assertion
 	claims, err := validateIDJAGAssertion(ctx, cfg, tgr.ClientID, assertion)
 	if err != nil {
 		return nil, err

--- a/store_replay.go
+++ b/store_replay.go
@@ -1,0 +1,40 @@
+package oauth2
+
+import (
+	"context"
+	stderrors "errors"
+	"sync"
+	"time"
+)
+
+type AssertionReplayStore interface {
+	StoreAssertionID(ctx context.Context, jti string, exp time.Time) error
+}
+
+type memoryAssertionReplayStore struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+func NewMemoryAssertionReplayStore() AssertionReplayStore {
+	return &memoryAssertionReplayStore{entries: make(map[string]time.Time)}
+}
+
+func (s *memoryAssertionReplayStore) StoreAssertionID(ctx context.Context, jti string, exp time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for k, e := range s.entries {
+		if now.After(e) {
+			delete(s.entries, k)
+		}
+	}
+	if _, ok := s.entries[jti]; ok {
+		return stderrors.New("jti already used")
+	}
+	s.entries[jti] = exp
+	return nil
+}

--- a/store_replay_test.go
+++ b/store_replay_test.go
@@ -1,0 +1,52 @@
+package oauth2_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-oauth2/oauth2/v4"
+)
+
+func TestMemoryAssertionReplayStore(t *testing.T) {
+	t.Run("first store succeeds", func(t *testing.T) {
+		s := oauth2.NewMemoryAssertionReplayStore()
+		if err := s.StoreAssertionID(context.Background(), "jti-1", time.Now().Add(5*time.Minute)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("duplicate before exp returns error", func(t *testing.T) {
+		s := oauth2.NewMemoryAssertionReplayStore()
+		exp := time.Now().Add(5 * time.Minute)
+		if err := s.StoreAssertionID(context.Background(), "jti-dup", exp); err != nil {
+			t.Fatalf("first store: %v", err)
+		}
+		if err := s.StoreAssertionID(context.Background(), "jti-dup", exp); err == nil {
+			t.Error("expected error for duplicate jti, got nil")
+		}
+	})
+
+	t.Run("same jti accepted after exp", func(t *testing.T) {
+		s := oauth2.NewMemoryAssertionReplayStore()
+		// Store with an already-expired exp so the sweep removes it on next call.
+		pastExp := time.Now().Add(-1 * time.Millisecond)
+		if err := s.StoreAssertionID(context.Background(), "jti-expired", pastExp); err != nil {
+			t.Fatalf("initial store: %v", err)
+		}
+		// A tiny sleep ensures the exp timestamp is in the past when StoreAssertionID runs.
+		time.Sleep(5 * time.Millisecond)
+		if err := s.StoreAssertionID(context.Background(), "jti-expired", time.Now().Add(5*time.Minute)); err != nil {
+			t.Errorf("after expiry: %v", err)
+		}
+	})
+
+	t.Run("cancelled context returns error", func(t *testing.T) {
+		s := oauth2.NewMemoryAssertionReplayStore()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := s.StoreAssertionID(ctx, "jti-cancel", time.Now().Add(5*time.Minute)); err == nil {
+			t.Error("expected error from cancelled context, got nil")
+		}
+	})
+}


### PR DESCRIPTION
**feat: implement Identity Assertion Authorization Grant (ID-JAG) — RFC 7523**

---

  Implements the Identity Assertion JWT Authorization Grant per draft-ietf-oauth-identity-assertion-authz-grant-03 (https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/),
  allowing this server to act as a Resource Authorization Server that accepts ID-JAG assertions from trusted external IdPs and issues scoped access tokens.

  What's new

  **Grant registration (const.go)**
  - Adds JWTBearer grant type constant (urn:ietf:params:oauth:grant-type:jwt-bearer)

  **Assertion validation (server/idjag.go)**
  - Two-pass JWT validation: unverified parse for header dispatch only (typ, alg, kid), then full signature verification before any claim is trusted
  - Enforces typ: oauth-id-jag+jwt, asymmetric-only alg allowlist (RS256, ES256, PS256), trusted issuer allowlist, aud/client_id/jti/exp/iat checks
  - Clock skew (IDJAGClockSkew, default 60s) applied to exp, nbf, and iat 
  - Optional replay protection via pluggable AssertionReplayStore 
  - Reference OIDC discovery key resolver (NewOIDCIssuerKeyResolver) — stdlib only, no new dependencies
  
  **Grant handler (server/server.go)**
  - handleIDJAGGrant: fail-closed config validation, public client guard with boot-time warning, optional IDJAGAuthorizationHandler policy hook for scope/resource narrowing
  
  **Replay store (store_replay.go)**
  - AssertionReplayStore interface (additive — existing TokenStore implementations unaffected)
  - NewMemoryAssertionReplayStore() in-memory reference implementation
  
  **Config (server/config.go, manage/config.go, manage/manager.go)**
  - 7 new Config fields: TrustedIDJAGIssuers, IDJAGAudience, IDJAGClockSkew, IDJAGAllowPublicClients, IDJAGIssuerKeyResolver, IDJAGAuthorizationHandler, IDJAGReplayStore
  - DefaultJWTBearerTokenCfg: 2h access token, no refresh token (per spec §4.4.3)
  - SetGrantTypeCfg for operator override
  
  **Error mapping (errors/)**
  - ErrInsufficientUserAuthentication (insufficient_user_authentication, HTTP 400) per §8.2
  - Correct codes throughout: malformed assertion → ErrInvalidRequest; grant not in AllowedGrantTypes → ErrUnsupportedGrantType

  **Tests**

  - server/idjag_test.go — 14 cases covering type confusion, algorithm confusion, untrusted issuer, audience mismatch, client_id binding, clock skew, missing claims, replay
  - store_replay_test.go — 4 cases covering first store, duplicate rejection, post-expiry reuse, context cancellation

